### PR TITLE
:sparkles: Add mintChamberWithPermit

### DIFF
--- a/config.js
+++ b/config.js
@@ -18,11 +18,21 @@ const ADDYTokenParams = {
   basketAddress: '0xE15A66b7B8e385CAa6F69FD0d55984B96D7263CF',
 }
 
+const AAGGTokenParams = {
+  tokenAddress: '0x6b175474e89094c44da98b954eedeac495271d0f',
+  slippagePercentageProportion: 0.05,
+  networkId: 137,
+  issuanceModuleAddress: '0x60F56236CD3C1Ac146BD94F2006a1335BaA4c449',
+  isDebtIssuance: true,
+  basketAmountInWei: '',
+  basketAddress: '0xAfb6E8331355faE99C8E8953bB4c6Dc5d11E9F3c',
+}
 
 
 const archTokens = {
   "0x6cA9C8914a14D63a6700556127D09e7721ff7D3b": AP60TokenParams,
   "0xE15A66b7B8e385CAa6F69FD0d55984B96D7263CF": ADDYTokenParams,
+  "0xAfb6E8331355faE99C8E8953bB4c6Dc5d11E9F3c": AAGGTokenParams,
 }
 
 module.exports = {

--- a/config.js
+++ b/config.js
@@ -19,7 +19,7 @@ const ADDYTokenParams = {
 }
 
 const AAGGTokenParams = {
-  tokenAddress: '0x6b175474e89094c44da98b954eedeac495271d0f',
+  tokenAddress: '0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174',
   slippagePercentageProportion: 0.05,
   networkId: 137,
   issuanceModuleAddress: '0x60F56236CD3C1Ac146BD94F2006a1335BaA4c449',

--- a/src/Gasworks.sol
+++ b/src/Gasworks.sol
@@ -236,8 +236,10 @@ contract Gasworks is IGasworks, ERC2771Recipient, Owned {
 
         uint256 totalPaid = beforeBalance - token.balanceOf(address(this));
 
-        ERC20(address(mintChamberData._chamber)).safeTransfer(owner, mintChamberData._mintAmount);
-        token.safeTransfer(owner, token.balanceOf(address(this)));
+        ERC20(address(mintChamberData._chamber)).safeTransfer(
+            permit._owner, mintChamberData._mintAmount
+        );
+        token.safeTransfer(permit._owner, token.balanceOf(address(this)));
 
         emit MintWithPermit(
             address(mintChamberData._chamber),

--- a/src/interfaces/IGasworks.sol
+++ b/src/interfaces/IGasworks.sol
@@ -183,6 +183,12 @@ interface IGasworks {
 
     function mintWithPermit(PermitData calldata permit, MintSetData calldata mintData) external;
 
+    function mintChamberWithPermit(
+        PermitData calldata permit,
+        MintChamberData calldata mintChamberData,
+        ITradeIssuerV2.ContractCallInstruction[] memory contractCallInstructions
+    ) external;
+
     function swapWithPermit2(
         ISignatureTransfer.PermitTransferFrom memory permit2,
         ISignatureTransfer.SignatureTransferDetails calldata transferDetails,

--- a/test/permit/mintChamberWithPermit.t.sol
+++ b/test/permit/mintChamberWithPermit.t.sol
@@ -46,8 +46,17 @@ contract GaslessTest is Test, ChamberTestUtils {
         gasworks.setTokens(address(USDC));
         gasworks.setTokens(address(AAGG));
 
+        vm.label(0x2B13D2b9407D5776B0BB63c8cd144978B6B7cE58, "TradeIssuerV2");
+
+        sigUtils = new SigUtils(IERC20Permit(address(USDC)).DOMAIN_SEPARATOR());
+
         ownerPrivateKey = 0xA11CE;
         owner = vm.addr(ownerPrivateKey);
+
+        vm.prank(0xe560EfD37a77486aa0ecAed4203365BDe5363dbB);
+        ITradeIssuerV2(0x2B13D2b9407D5776B0BB63c8cd144978B6B7cE58).addTarget(
+            0xDef1C0ded9bec7F1a1670819833240f027b25EfF
+        );
 
         string[] memory inputs = new string[](6);
         inputs[0] = "node";
@@ -64,388 +73,390 @@ contract GaslessTest is Test, ChamberTestUtils {
         nonce = IERC20Permit(address(USDC)).nonces(owner);
     }
 
-    // /*//////////////////////////////////////////////////////////////
-    //                           REVERT
-    // //////////////////////////////////////////////////////////////*/
+    /*//////////////////////////////////////////////////////////////
+                              REVERT
+    //////////////////////////////////////////////////////////////*/
 
-    // /**
-    //  * [REVERT] Should revert because the permit is expired
-    //  */
-    // function testCannotMintWithExpiredPermit() public {
-    //     (
-    //         ITradeIssuerV2.ContractCallInstruction[] memory _contractCallInstructions,
-    //         uint256 _maxPayAmount
-    //     ) = abi.decode(res, (ITradeIssuerV2.ContractCallInstruction[], uint256));
-    //     mintData = IGasworks.MintChamberData(
-    //         AAGG,
-    //         IIssuerWizard(0x60F56236CD3C1Ac146BD94F2006a1335BaA4c449),
-    //         USDC,
-    //         _maxPayAmount,
-    //         amountToMint
-    //     );
+    /**
+     * [REVERT] Should revert because the permit is expired
+     */
+    function testCannotMintWithExpiredPermit() public {
+        (
+            ITradeIssuerV2.ContractCallInstruction[] memory _contractCallInstructions,
+            uint256 _maxPayAmount
+        ) = abi.decode(res, (ITradeIssuerV2.ContractCallInstruction[], uint256));
+        mintData = IGasworks.MintChamberData(
+            AAGG,
+            IIssuerWizard(0x60F56236CD3C1Ac146BD94F2006a1335BaA4c449),
+            USDC,
+            _maxPayAmount,
+            amountToMint
+        );
 
-    //     SigUtils.Permit memory permit = SigUtils.Permit({
-    //         owner: owner,
-    //         spender: address(gasworks),
-    //         value: 1e18,
-    //         nonce: nonce,
-    //         deadline: 2 ** 255 - 1
-    //     });
+        SigUtils.Permit memory permit = SigUtils.Permit({
+            owner: owner,
+            spender: address(gasworks),
+            value: 1e18,
+            nonce: nonce,
+            deadline: 2 ** 255 - 1
+        });
 
-    //     bytes32 digest = sigUtils.getTypedDataHash(permit);
+        bytes32 digest = sigUtils.getTypedDataHash(permit);
 
-    //     (uint8 v, bytes32 r, bytes32 s) = vm.sign(ownerPrivateKey, digest);
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(ownerPrivateKey, digest);
 
-    //     vm.warp(2 ** 255 + 1); // fast forwards one second past the deadline
+        vm.warp(2 ** 255 + 1); // fast forwards one second past the deadline
 
-    //     vm.expectRevert("Permit: permit is expired");
-    //     gasworks.mintChamberWithPermit(
-    //         IGasworks.PermitData(
-    //             address(USDC),
-    //             1e18,
-    //             permit.owner,
-    //             permit.spender,
-    //             permit.value,
-    //             permit.deadline,
-    //             v,
-    //             r,
-    //             s
-    //         ),
-    //         mintData,
-    //         _contractCallInstructions
-    //     );
-    // }
+        vm.expectRevert("Permit: permit is expired");
+        gasworks.mintChamberWithPermit(
+            IGasworks.PermitData(
+                address(USDC),
+                1e18,
+                permit.owner,
+                permit.spender,
+                permit.value,
+                permit.deadline,
+                v,
+                r,
+                s
+            ),
+            mintData,
+            _contractCallInstructions
+        );
+    }
 
-    // /**
-    //  * [REVERT] Should revert because the signer of the permit
-    //  * is not the owner of the tokens
-    //  */
-    // function testCannotMintWithInvalidSigner() public {
-    //     (
-    //         ITradeIssuerV2.ContractCallInstruction[] memory _contractCallInstructions,
-    //         uint256 _maxPayAmount
-    //     ) = abi.decode(res, (ITradeIssuerV2.ContractCallInstruction[], uint256));
-    //     mintData = IGasworks.MintChamberData(
-    //         AAGG,
-    //         IIssuerWizard(0x60F56236CD3C1Ac146BD94F2006a1335BaA4c449),
-    //         USDC,
-    //         _maxPayAmount,
-    //         amountToMint
-    //     );
+    /**
+     * [REVERT] Should revert because the signer of the permit
+     * is not the owner of the tokens
+     */
+    function testCannotMintWithInvalidSigner() public {
+        (
+            ITradeIssuerV2.ContractCallInstruction[] memory _contractCallInstructions,
+            uint256 _maxPayAmount
+        ) = abi.decode(res, (ITradeIssuerV2.ContractCallInstruction[], uint256));
+        mintData = IGasworks.MintChamberData(
+            AAGG,
+            IIssuerWizard(0x60F56236CD3C1Ac146BD94F2006a1335BaA4c449),
+            USDC,
+            _maxPayAmount,
+            amountToMint
+        );
 
-    //     SigUtils.Permit memory permit = SigUtils.Permit({
-    //         owner: owner,
-    //         spender: address(gasworks),
-    //         value: 1e18,
-    //         nonce: nonce,
-    //         deadline: 2 ** 256 - 1
-    //     });
+        SigUtils.Permit memory permit = SigUtils.Permit({
+            owner: owner,
+            spender: address(gasworks),
+            value: 1e18,
+            nonce: nonce,
+            deadline: 2 ** 256 - 1
+        });
 
-    //     bytes32 digest = sigUtils.getTypedDataHash(permit);
+        bytes32 digest = sigUtils.getTypedDataHash(permit);
 
-    //     (uint8 v, bytes32 r, bytes32 s) = vm.sign(0xB0B, digest); // 0xB0B signs but 0xA11CE is owner
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(0xB0B, digest); // 0xB0B signs but 0xA11CE is owner
 
-    //     vm.expectRevert("Permit: invalid signature");
-    //     gasworks.mintChamberWithPermit(
-    //         IGasworks.PermitData(
-    //             address(USDC),
-    //             1e18,
-    //             permit.owner,
-    //             permit.spender,
-    //             permit.value,
-    //             permit.deadline,
-    //             v,
-    //             r,
-    //             s
-    //         ),
-    //         mintData,
-    //         _contractCallInstructions
-    //     );
-    // }
+        vm.expectRevert("Permit: invalid signature");
+        gasworks.mintChamberWithPermit(
+            IGasworks.PermitData(
+                address(USDC),
+                1e18,
+                permit.owner,
+                permit.spender,
+                permit.value,
+                permit.deadline,
+                v,
+                r,
+                s
+            ),
+            mintData,
+            _contractCallInstructions
+        );
+    }
 
-    // /**
-    //  * [REVERT] Should revert because the nonce is invalid
-    //  */
-    // function testCannotMintWithInvalidNonce() public {
-    //     (
-    //         ITradeIssuerV2.ContractCallInstruction[] memory _contractCallInstructions,
-    //         uint256 _maxPayAmount
-    //     ) = abi.decode(res, (ITradeIssuerV2.ContractCallInstruction[], uint256));
-    //     mintData = IGasworks.MintChamberData(
-    //         AAGG,
-    //         IIssuerWizard(0x60F56236CD3C1Ac146BD94F2006a1335BaA4c449),
-    //         USDC,
-    //         _maxPayAmount,
-    //         amountToMint
-    //     );
+    /**
+     * [REVERT] Should revert because the nonce is invalid
+     */
+    function testCannotMintWithInvalidNonce() public {
+        (
+            ITradeIssuerV2.ContractCallInstruction[] memory _contractCallInstructions,
+            uint256 _maxPayAmount
+        ) = abi.decode(res, (ITradeIssuerV2.ContractCallInstruction[], uint256));
+        mintData = IGasworks.MintChamberData(
+            AAGG,
+            IIssuerWizard(0x60F56236CD3C1Ac146BD94F2006a1335BaA4c449),
+            USDC,
+            _maxPayAmount,
+            amountToMint
+        );
 
-    //     SigUtils.Permit memory permit = SigUtils.Permit({
-    //         owner: owner,
-    //         spender: address(gasworks),
-    //         value: 1e18,
-    //         nonce: 1, // set nonce to 1 instead of 0
-    //         deadline: 2 ** 256 - 1
-    //     });
+        SigUtils.Permit memory permit = SigUtils.Permit({
+            owner: owner,
+            spender: address(gasworks),
+            value: 1e18,
+            nonce: 1, // set nonce to 1 instead of 0
+            deadline: 2 ** 256 - 1
+        });
 
-    //     bytes32 digest = sigUtils.getTypedDataHash(permit);
+        bytes32 digest = sigUtils.getTypedDataHash(permit);
 
-    //     (uint8 v, bytes32 r, bytes32 s) = vm.sign(ownerPrivateKey, digest);
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(ownerPrivateKey, digest);
 
-    //     vm.expectRevert("Permit: invalid signature");
-    //     gasworks.mintChamberWithPermit(
-    //         IGasworks.PermitData(
-    //             address(USDC),
-    //             1e18,
-    //             permit.owner,
-    //             permit.spender,
-    //             permit.value,
-    //             permit.deadline,
-    //             v,
-    //             r,
-    //             s
-    //         ),
-    //         mintData,
-    //         _contractCallInstructions
-    //     );
-    // }
+        vm.expectRevert("Permit: invalid signature");
+        gasworks.mintChamberWithPermit(
+            IGasworks.PermitData(
+                address(USDC),
+                1e18,
+                permit.owner,
+                permit.spender,
+                permit.value,
+                permit.deadline,
+                v,
+                r,
+                s
+            ),
+            mintData,
+            _contractCallInstructions
+        );
+    }
 
-    // /**
-    //  * [REVERT] Should revert because allowed amount is less than required amount
-    //  */
-    // function testCannotMintWithInvalidAllowance() public {
-    //     (
-    //         ITradeIssuerV2.ContractCallInstruction[] memory _contractCallInstructions,
-    //         uint256 _maxPayAmount
-    //     ) = abi.decode(res, (ITradeIssuerV2.ContractCallInstruction[], uint256));
-    //     mintData = IGasworks.MintChamberData(
-    //         AAGG,
-    //         IIssuerWizard(0x60F56236CD3C1Ac146BD94F2006a1335BaA4c449),
-    //         USDC,
-    //         _maxPayAmount,
-    //         amountToMint
-    //     );
+    /**
+     * [REVERT] Should revert because allowed amount is less than required amount
+     */
+    function testCannotMintWithInvalidAllowance() public {
+        (
+            ITradeIssuerV2.ContractCallInstruction[] memory _contractCallInstructions,
+            uint256 _maxPayAmount
+        ) = abi.decode(res, (ITradeIssuerV2.ContractCallInstruction[], uint256));
+        mintData = IGasworks.MintChamberData(
+            AAGG,
+            IIssuerWizard(0x60F56236CD3C1Ac146BD94F2006a1335BaA4c449),
+            USDC,
+            _maxPayAmount,
+            amountToMint
+        );
 
-    //     SigUtils.Permit memory permit = SigUtils.Permit({
-    //         owner: owner,
-    //         spender: address(gasworks),
-    //         value: 5e5,
-    //         nonce: 0,
-    //         deadline: 2 ** 256 - 1
-    //     });
+        SigUtils.Permit memory permit = SigUtils.Permit({
+            owner: owner,
+            spender: address(gasworks),
+            value: 5e5,
+            nonce: 0,
+            deadline: 2 ** 256 - 1
+        });
 
-    //     bytes32 digest = sigUtils.getTypedDataHash(permit);
+        bytes32 digest = sigUtils.getTypedDataHash(permit);
 
-    //     (uint8 v, bytes32 r, bytes32 s) = vm.sign(ownerPrivateKey, digest);
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(ownerPrivateKey, digest);
 
-    //     vm.expectRevert("TRANSFER_FROM_FAILED");
-    //     gasworks.mintChamberWithPermit(
-    //         IGasworks.PermitData(
-    //             address(USDC),
-    //             1e18,
-    //             permit.owner,
-    //             permit.spender,
-    //             permit.value,
-    //             permit.deadline,
-    //             v,
-    //             r,
-    //             s
-    //         ),
-    //         mintData,
-    //         _contractCallInstructions
-    //     );
-    // }
+        vm.expectRevert("TRANSFER_FROM_FAILED");
+        gasworks.mintChamberWithPermit(
+            IGasworks.PermitData(
+                address(USDC),
+                1e18,
+                permit.owner,
+                permit.spender,
+                permit.value,
+                permit.deadline,
+                v,
+                r,
+                s
+            ),
+            mintData,
+            _contractCallInstructions
+        );
+    }
 
-    // /**
-    //  * [REVERT] Should revert because balance is less than required amount
-    //  */
-    // function testCannotMintWithInvalidBalance() public {
-    //     (
-    //         ITradeIssuerV2.ContractCallInstruction[] memory _contractCallInstructions,
-    //         uint256 _maxPayAmount
-    //     ) = abi.decode(res, (ITradeIssuerV2.ContractCallInstruction[], uint256));
-    //     mintData = IGasworks.MintChamberData(
-    //         AAGG,
-    //         IIssuerWizard(0x60F56236CD3C1Ac146BD94F2006a1335BaA4c449),
-    //         USDC,
-    //         _maxPayAmount,
-    //         amountToMint
-    //     );
+    /**
+     * [REVERT] Should revert because balance is less than required amount
+     */
+    function testCannotMintWithInvalidBalance() public {
+        (
+            ITradeIssuerV2.ContractCallInstruction[] memory _contractCallInstructions,
+            uint256 _maxPayAmount
+        ) = abi.decode(res, (ITradeIssuerV2.ContractCallInstruction[], uint256));
+        mintData = IGasworks.MintChamberData(
+            AAGG,
+            IIssuerWizard(0x60F56236CD3C1Ac146BD94F2006a1335BaA4c449),
+            USDC,
+            _maxPayAmount,
+            amountToMint
+        );
 
-    //     SigUtils.Permit memory permit = SigUtils.Permit({
-    //         owner: owner,
-    //         spender: address(gasworks),
-    //         value: 2e18,
-    //         nonce: 0,
-    //         deadline: 2 ** 256 - 1
-    //     });
+        SigUtils.Permit memory permit = SigUtils.Permit({
+            owner: owner,
+            spender: address(gasworks),
+            value: 2e18,
+            nonce: 0,
+            deadline: 2 ** 256 - 1
+        });
 
-    //     bytes32 digest = sigUtils.getTypedDataHash(permit);
+        bytes32 digest = sigUtils.getTypedDataHash(permit);
 
-    //     (uint8 v, bytes32 r, bytes32 s) = vm.sign(ownerPrivateKey, digest);
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(ownerPrivateKey, digest);
 
-    //     vm.expectRevert("TRANSFER_FROM_FAILED");
-    //     gasworks.mintChamberWithPermit(
-    //         IGasworks.PermitData(
-    //             address(USDC),
-    //             2e18, // owner was only minted 1 USDC
-    //             permit.owner,
-    //             permit.spender,
-    //             permit.value,
-    //             permit.deadline,
-    //             v,
-    //             r,
-    //             s
-    //         ),
-    //         mintData,
-    //         _contractCallInstructions
-    //     );
-    // }
+        vm.expectRevert("TRANSFER_FROM_FAILED");
+        gasworks.mintChamberWithPermit(
+            IGasworks.PermitData(
+                address(USDC),
+                2e18, // owner was only minted 1 USDC
+                permit.owner,
+                permit.spender,
+                permit.value,
+                permit.deadline,
+                v,
+                r,
+                s
+            ),
+            mintData,
+            _contractCallInstructions
+        );
+    }
 
-    // /**
-    //  * [REVERT] Should revert because mintData is invalid
-    //  */
-    // function testCannotMintWithInvalidPayload() public {
-    //     (
-    //         ITradeIssuerV2.ContractCallInstruction[] memory _contractCallInstructions,
-    //         uint256 _maxPayAmount
-    //     ) = abi.decode(res, (ITradeIssuerV2.ContractCallInstruction[], uint256));
-    //     mintData = IGasworks.MintChamberData(
-    //         AAGG,
-    //         IIssuerWizard(0x60F56236CD3C1Ac146BD94F2006a1335BaA4c449),
-    //         USDC,
-    //         _maxPayAmount,
-    //         amountToMint
-    //     );
+    /**
+     * [REVERT] Should revert because mintData is invalid
+     */
+    function testCannotMintWithInvalidPayload() public {
+        (
+            ITradeIssuerV2.ContractCallInstruction[] memory _contractCallInstructions,
+            uint256 _maxPayAmount
+        ) = abi.decode(res, (ITradeIssuerV2.ContractCallInstruction[], uint256));
+        mintData = IGasworks.MintChamberData(
+            AAGG,
+            IIssuerWizard(0x60F56236CD3C1Ac146BD94F2006a1335BaA4c449),
+            USDC,
+            _maxPayAmount,
+            amountToMint
+        );
 
-    //     _contractCallInstructions[0]._callData = bytes("bad data");
+        _contractCallInstructions[0]._callData = bytes("bad data");
 
-    //     SigUtils.Permit memory permit = SigUtils.Permit({
-    //         owner: owner,
-    //         spender: address(gasworks),
-    //         value: mintData._maxPayAmount,
-    //         nonce: nonce,
-    //         deadline: 2 ** 256 - 1
-    //     });
+        SigUtils.Permit memory permit = SigUtils.Permit({
+            owner: owner,
+            spender: address(gasworks),
+            value: mintData._maxPayAmount,
+            nonce: nonce,
+            deadline: 2 ** 256 - 1
+        });
 
-    //     bytes32 digest = sigUtils.getTypedDataHash(permit);
+        bytes32 digest = sigUtils.getTypedDataHash(permit);
 
-    //     (uint8 v, bytes32 r, bytes32 s) = vm.sign(ownerPrivateKey, digest);
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(ownerPrivateKey, digest);
 
-    //     vm.expectRevert();
-    //     gasworks.mintChamberWithPermit(
-    //         IGasworks.PermitData(
-    //             address(USDC),
-    //             mintData._maxPayAmount,
-    //             permit.owner,
-    //             permit.spender,
-    //             permit.value,
-    //             permit.deadline,
-    //             v,
-    //             r,
-    //             s
-    //         ),
-    //         mintData,
-    //         _contractCallInstructions
-    //     );
-    // }
+        vm.expectRevert();
+        gasworks.mintChamberWithPermit(
+            IGasworks.PermitData(
+                address(USDC),
+                mintData._maxPayAmount,
+                permit.owner,
+                permit.spender,
+                permit.value,
+                permit.deadline,
+                v,
+                r,
+                s
+            ),
+            mintData,
+            _contractCallInstructions
+        );
+    }
 
-    // /**
-    //  * [REVERT] Should revert because token is not permitted
-    //  */
-    // function testCannotMintWithInvalidToken() public {
-    //     (
-    //         ITradeIssuerV2.ContractCallInstruction[] memory _contractCallInstructions,
-    //         uint256 _maxPayAmount
-    //     ) = abi.decode(res, (ITradeIssuerV2.ContractCallInstruction[], uint256));
-    //     mintData = IGasworks.MintChamberData(
-    //         AAGG,
-    //         IIssuerWizard(0x60F56236CD3C1Ac146BD94F2006a1335BaA4c449),
-    //         USDC,
-    //         _maxPayAmount,
-    //         amountToMint
-    //     );
+    /**
+     * [REVERT] Should revert because token is not permitted
+     */
+    function testCannotMintWithInvalidToken() public {
+        (
+            ITradeIssuerV2.ContractCallInstruction[] memory _contractCallInstructions,
+            uint256 _maxPayAmount
+        ) = abi.decode(res, (ITradeIssuerV2.ContractCallInstruction[], uint256));
+        mintData = IGasworks.MintChamberData(
+            AAGG,
+            IIssuerWizard(0x60F56236CD3C1Ac146BD94F2006a1335BaA4c449),
+            USDC,
+            _maxPayAmount,
+            amountToMint
+        );
 
-    //     SigUtils.Permit memory permit = SigUtils.Permit({
-    //         owner: owner,
-    //         spender: address(gasworks),
-    //         value: 1e6,
-    //         nonce: nonce,
-    //         deadline: 2 ** 256 - 1
-    //     });
+        SigUtils.Permit memory permit = SigUtils.Permit({
+            owner: owner,
+            spender: address(gasworks),
+            value: 1e6,
+            nonce: nonce,
+            deadline: 2 ** 256 - 1
+        });
 
-    //     bytes32 digest = sigUtils.getTypedDataHash(permit);
+        bytes32 digest = sigUtils.getTypedDataHash(permit);
 
-    //     (uint8 v, bytes32 r, bytes32 s) = vm.sign(ownerPrivateKey, digest);
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(ownerPrivateKey, digest);
 
-    //     vm.expectRevert(abi.encodeWithSelector(IGasworks.InvalidToken.selector, address(0x123123)));
-    //     gasworks.mintChamberWithPermit(
-    //         IGasworks.PermitData(
-    //             address(0x123123),
-    //             1e6,
-    //             permit.owner,
-    //             permit.spender,
-    //             permit.value,
-    //             permit.deadline,
-    //             v,
-    //             r,
-    //             s
-    //         ),
-    //         mintData,
-    //         _contractCallInstructions
-    //     );
-    // }
+        vm.expectRevert(abi.encodeWithSelector(IGasworks.InvalidToken.selector, address(0x123123)));
+        gasworks.mintChamberWithPermit(
+            IGasworks.PermitData(
+                address(0x123123),
+                1e6,
+                permit.owner,
+                permit.spender,
+                permit.value,
+                permit.deadline,
+                v,
+                r,
+                s
+            ),
+            mintData,
+            _contractCallInstructions
+        );
+    }
 
-    // /*//////////////////////////////////////////////////////////////
-    //                           SUCCESS
-    // //////////////////////////////////////////////////////////////*/
+    /*//////////////////////////////////////////////////////////////
+                              SUCCESS
+    //////////////////////////////////////////////////////////////*/
 
-    // /**
-    //  * [SUCCESS] Should make a mint of AAGG with USDC using EIP2612 permit
-    //  */
-    // function testMintChamberWithMaxPermit() public {
-    //     (
-    //         ITradeIssuerV2.ContractCallInstruction[] memory _contractCallInstructions,
-    //         uint256 _maxPayAmount
-    //     ) = abi.decode(res, (ITradeIssuerV2.ContractCallInstruction[], uint256));
-    //     mintData = IGasworks.MintChamberData(
-    //         AAGG,
-    //         IIssuerWizard(0x60F56236CD3C1Ac146BD94F2006a1335BaA4c449),
-    //         USDC,
-    //         _maxPayAmount,
-    //         amountToMint
-    //     );
+    /**
+     * [SUCCESS] Should make a mint of AAGG with USDC using EIP2612 permit
+     */
+    function testMintChamberWithMaxPermit() public {
+        (
+            ITradeIssuerV2.ContractCallInstruction[] memory _contractCallInstructions,
+            uint256 _maxPayAmount
+        ) = abi.decode(res, (ITradeIssuerV2.ContractCallInstruction[], uint256));
+        mintData = IGasworks.MintChamberData(
+            AAGG,
+            IIssuerWizard(0x60F56236CD3C1Ac146BD94F2006a1335BaA4c449),
+            USDC,
+            _maxPayAmount,
+            amountToMint
+        );
 
-    //     SigUtils.Permit memory permit = SigUtils.Permit({
-    //         owner: owner,
-    //         spender: address(gasworks),
-    //         value: type(uint256).max,
-    //         nonce: nonce,
-    //         deadline: 2 ** 256 - 1
-    //     });
+        SigUtils.Permit memory permit = SigUtils.Permit({
+            owner: owner,
+            spender: address(gasworks),
+            value: type(uint256).max,
+            nonce: nonce,
+            deadline: 2 ** 256 - 1
+        });
 
-    //     bytes32 digest = sigUtils.getTypedDataHash(permit);
+        bytes32 digest = sigUtils.getTypedDataHash(permit);
 
-    //     (uint8 v, bytes32 r, bytes32 s) = vm.sign(ownerPrivateKey, digest);
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(ownerPrivateKey, digest);
 
-    //     gasworks.mintChamberWithPermit(
-    //         IGasworks.PermitData(
-    //             address(USDC),
-    //             mintData._maxPayAmount,
-    //             permit.owner,
-    //             permit.spender,
-    //             permit.value,
-    //             permit.deadline,
-    //             v,
-    //             r,
-    //             s
-    //         ),
-    //         mintData,
-    //         _contractCallInstructions
-    //     );
+        gasworks.mintChamberWithPermit(
+            IGasworks.PermitData(
+                address(USDC),
+                mintData._maxPayAmount,
+                permit.owner,
+                permit.spender,
+                permit.value,
+                permit.deadline,
+                v,
+                r,
+                s
+            ),
+            mintData,
+            _contractCallInstructions
+        );
 
-    //     assertEq(USDC.balanceOf(address(gasworks)), 0);
-    //     assertEq(USDC.allowance(owner, address(gasworks)), 0);
-    //     assertEq(IERC20Permit(address(USDC)).nonces(owner), 1);
-    //     assertEq(IERC20(address(AAGG)).balanceOf(owner), amountToMint);
-    // }
+        assertEq(USDC.balanceOf(address(gasworks)), 0);
+        assertGe(
+            USDC.allowance(owner, address(gasworks)), type(uint256).max - mintData._maxPayAmount
+        );
+        assertEq(IERC20Permit(address(USDC)).nonces(owner), 1);
+        assertEq(IERC20(address(AAGG)).balanceOf(owner), amountToMint);
+    }
 }

--- a/test/permit/mintChamberWithPermit.t.sol
+++ b/test/permit/mintChamberWithPermit.t.sol
@@ -1,0 +1,451 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.17.0;
+
+import { Test } from "forge-std/Test.sol";
+import { Gasworks } from "src/Gasworks.sol";
+import { IGasworks } from "src/interfaces/IGasworks.sol";
+import { IERC20 } from "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
+import { SafeERC20 } from "openzeppelin-contracts/contracts/token/ERC20/utils/SafeERC20.sol";
+import { Conversor } from "test/utils/HexUtils.sol";
+import { ChamberTestUtils } from "chambers-peripherals/test/utils/ChamberTestUtils.sol";
+import { ITradeIssuerV2 } from "chambers-peripherals/src/interfaces/ITradeIssuerV2.sol";
+import { IChamber } from "chambers/interfaces/IChamber.sol";
+import { IIssuerWizard } from "chambers/interfaces/IIssuerWizard.sol";
+import { SigUtils } from "test/utils/SigUtils.sol";
+import { IERC20Permit } from
+    "openzeppelin-contracts/contracts/token/ERC20/extensions/IERC20Permit.sol";
+
+contract GaslessTest is Test, ChamberTestUtils {
+    /*//////////////////////////////////////////////////////////////
+                              VARIABLES
+    //////////////////////////////////////////////////////////////*/
+    using SafeERC20 for IERC20;
+
+    IERC20 internal constant USDC = IERC20(0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174);
+    IChamber internal constant AAGG = IChamber(0xAfb6E8331355faE99C8E8953bB4c6Dc5d11E9F3c);
+
+    Gasworks internal gasworks;
+    SigUtils internal sigUtils;
+    uint256 internal ownerPrivateKey;
+    address internal owner;
+
+    IGasworks.MintChamberData internal mintData;
+    bytes internal res;
+    uint256 internal amountToMint = 10e18;
+    uint256 internal nonce;
+
+    /*//////////////////////////////////////////////////////////////
+                              SET UP
+    //////////////////////////////////////////////////////////////*/
+    function setUp() public {
+        gasworks = new Gasworks(
+            0xdA78a11FD57aF7be2eDD804840eA7f4c2A38801d,
+            0x1c0c05a2aA31692e5dc9511b04F651db9E4d8320,
+            0x2B13D2b9407D5776B0BB63c8cd144978B6B7cE58
+        );
+        gasworks.setTokens(address(USDC));
+        gasworks.setTokens(address(AAGG));
+
+        ownerPrivateKey = 0xA11CE;
+        owner = vm.addr(ownerPrivateKey);
+
+        string[] memory inputs = new string[](6);
+        inputs[0] = "node";
+        inputs[1] = "scripts/fetch-arch-quote.js";
+        inputs[2] = Conversor.iToHex(abi.encode(amountToMint));
+        inputs[3] = Conversor.iToHex(abi.encode(address(AAGG)));
+        inputs[4] = Conversor.iToHex(abi.encode(address(USDC)));
+        inputs[5] = Conversor.iToHex(abi.encode(true));
+        res = vm.ffi(inputs);
+
+        vm.prank(0xe7804c37c13166fF0b37F5aE0BB07A3aEbb6e245);
+        USDC.safeTransfer(owner, 150e6);
+
+        nonce = IERC20Permit(address(USDC)).nonces(owner);
+    }
+
+    // /*//////////////////////////////////////////////////////////////
+    //                           REVERT
+    // //////////////////////////////////////////////////////////////*/
+
+    // /**
+    //  * [REVERT] Should revert because the permit is expired
+    //  */
+    // function testCannotMintWithExpiredPermit() public {
+    //     (
+    //         ITradeIssuerV2.ContractCallInstruction[] memory _contractCallInstructions,
+    //         uint256 _maxPayAmount
+    //     ) = abi.decode(res, (ITradeIssuerV2.ContractCallInstruction[], uint256));
+    //     mintData = IGasworks.MintChamberData(
+    //         AAGG,
+    //         IIssuerWizard(0x60F56236CD3C1Ac146BD94F2006a1335BaA4c449),
+    //         USDC,
+    //         _maxPayAmount,
+    //         amountToMint
+    //     );
+
+    //     SigUtils.Permit memory permit = SigUtils.Permit({
+    //         owner: owner,
+    //         spender: address(gasworks),
+    //         value: 1e18,
+    //         nonce: nonce,
+    //         deadline: 2 ** 255 - 1
+    //     });
+
+    //     bytes32 digest = sigUtils.getTypedDataHash(permit);
+
+    //     (uint8 v, bytes32 r, bytes32 s) = vm.sign(ownerPrivateKey, digest);
+
+    //     vm.warp(2 ** 255 + 1); // fast forwards one second past the deadline
+
+    //     vm.expectRevert("Permit: permit is expired");
+    //     gasworks.mintChamberWithPermit(
+    //         IGasworks.PermitData(
+    //             address(USDC),
+    //             1e18,
+    //             permit.owner,
+    //             permit.spender,
+    //             permit.value,
+    //             permit.deadline,
+    //             v,
+    //             r,
+    //             s
+    //         ),
+    //         mintData,
+    //         _contractCallInstructions
+    //     );
+    // }
+
+    // /**
+    //  * [REVERT] Should revert because the signer of the permit
+    //  * is not the owner of the tokens
+    //  */
+    // function testCannotMintWithInvalidSigner() public {
+    //     (
+    //         ITradeIssuerV2.ContractCallInstruction[] memory _contractCallInstructions,
+    //         uint256 _maxPayAmount
+    //     ) = abi.decode(res, (ITradeIssuerV2.ContractCallInstruction[], uint256));
+    //     mintData = IGasworks.MintChamberData(
+    //         AAGG,
+    //         IIssuerWizard(0x60F56236CD3C1Ac146BD94F2006a1335BaA4c449),
+    //         USDC,
+    //         _maxPayAmount,
+    //         amountToMint
+    //     );
+
+    //     SigUtils.Permit memory permit = SigUtils.Permit({
+    //         owner: owner,
+    //         spender: address(gasworks),
+    //         value: 1e18,
+    //         nonce: nonce,
+    //         deadline: 2 ** 256 - 1
+    //     });
+
+    //     bytes32 digest = sigUtils.getTypedDataHash(permit);
+
+    //     (uint8 v, bytes32 r, bytes32 s) = vm.sign(0xB0B, digest); // 0xB0B signs but 0xA11CE is owner
+
+    //     vm.expectRevert("Permit: invalid signature");
+    //     gasworks.mintChamberWithPermit(
+    //         IGasworks.PermitData(
+    //             address(USDC),
+    //             1e18,
+    //             permit.owner,
+    //             permit.spender,
+    //             permit.value,
+    //             permit.deadline,
+    //             v,
+    //             r,
+    //             s
+    //         ),
+    //         mintData,
+    //         _contractCallInstructions
+    //     );
+    // }
+
+    // /**
+    //  * [REVERT] Should revert because the nonce is invalid
+    //  */
+    // function testCannotMintWithInvalidNonce() public {
+    //     (
+    //         ITradeIssuerV2.ContractCallInstruction[] memory _contractCallInstructions,
+    //         uint256 _maxPayAmount
+    //     ) = abi.decode(res, (ITradeIssuerV2.ContractCallInstruction[], uint256));
+    //     mintData = IGasworks.MintChamberData(
+    //         AAGG,
+    //         IIssuerWizard(0x60F56236CD3C1Ac146BD94F2006a1335BaA4c449),
+    //         USDC,
+    //         _maxPayAmount,
+    //         amountToMint
+    //     );
+
+    //     SigUtils.Permit memory permit = SigUtils.Permit({
+    //         owner: owner,
+    //         spender: address(gasworks),
+    //         value: 1e18,
+    //         nonce: 1, // set nonce to 1 instead of 0
+    //         deadline: 2 ** 256 - 1
+    //     });
+
+    //     bytes32 digest = sigUtils.getTypedDataHash(permit);
+
+    //     (uint8 v, bytes32 r, bytes32 s) = vm.sign(ownerPrivateKey, digest);
+
+    //     vm.expectRevert("Permit: invalid signature");
+    //     gasworks.mintChamberWithPermit(
+    //         IGasworks.PermitData(
+    //             address(USDC),
+    //             1e18,
+    //             permit.owner,
+    //             permit.spender,
+    //             permit.value,
+    //             permit.deadline,
+    //             v,
+    //             r,
+    //             s
+    //         ),
+    //         mintData,
+    //         _contractCallInstructions
+    //     );
+    // }
+
+    // /**
+    //  * [REVERT] Should revert because allowed amount is less than required amount
+    //  */
+    // function testCannotMintWithInvalidAllowance() public {
+    //     (
+    //         ITradeIssuerV2.ContractCallInstruction[] memory _contractCallInstructions,
+    //         uint256 _maxPayAmount
+    //     ) = abi.decode(res, (ITradeIssuerV2.ContractCallInstruction[], uint256));
+    //     mintData = IGasworks.MintChamberData(
+    //         AAGG,
+    //         IIssuerWizard(0x60F56236CD3C1Ac146BD94F2006a1335BaA4c449),
+    //         USDC,
+    //         _maxPayAmount,
+    //         amountToMint
+    //     );
+
+    //     SigUtils.Permit memory permit = SigUtils.Permit({
+    //         owner: owner,
+    //         spender: address(gasworks),
+    //         value: 5e5,
+    //         nonce: 0,
+    //         deadline: 2 ** 256 - 1
+    //     });
+
+    //     bytes32 digest = sigUtils.getTypedDataHash(permit);
+
+    //     (uint8 v, bytes32 r, bytes32 s) = vm.sign(ownerPrivateKey, digest);
+
+    //     vm.expectRevert("TRANSFER_FROM_FAILED");
+    //     gasworks.mintChamberWithPermit(
+    //         IGasworks.PermitData(
+    //             address(USDC),
+    //             1e18,
+    //             permit.owner,
+    //             permit.spender,
+    //             permit.value,
+    //             permit.deadline,
+    //             v,
+    //             r,
+    //             s
+    //         ),
+    //         mintData,
+    //         _contractCallInstructions
+    //     );
+    // }
+
+    // /**
+    //  * [REVERT] Should revert because balance is less than required amount
+    //  */
+    // function testCannotMintWithInvalidBalance() public {
+    //     (
+    //         ITradeIssuerV2.ContractCallInstruction[] memory _contractCallInstructions,
+    //         uint256 _maxPayAmount
+    //     ) = abi.decode(res, (ITradeIssuerV2.ContractCallInstruction[], uint256));
+    //     mintData = IGasworks.MintChamberData(
+    //         AAGG,
+    //         IIssuerWizard(0x60F56236CD3C1Ac146BD94F2006a1335BaA4c449),
+    //         USDC,
+    //         _maxPayAmount,
+    //         amountToMint
+    //     );
+
+    //     SigUtils.Permit memory permit = SigUtils.Permit({
+    //         owner: owner,
+    //         spender: address(gasworks),
+    //         value: 2e18,
+    //         nonce: 0,
+    //         deadline: 2 ** 256 - 1
+    //     });
+
+    //     bytes32 digest = sigUtils.getTypedDataHash(permit);
+
+    //     (uint8 v, bytes32 r, bytes32 s) = vm.sign(ownerPrivateKey, digest);
+
+    //     vm.expectRevert("TRANSFER_FROM_FAILED");
+    //     gasworks.mintChamberWithPermit(
+    //         IGasworks.PermitData(
+    //             address(USDC),
+    //             2e18, // owner was only minted 1 USDC
+    //             permit.owner,
+    //             permit.spender,
+    //             permit.value,
+    //             permit.deadline,
+    //             v,
+    //             r,
+    //             s
+    //         ),
+    //         mintData,
+    //         _contractCallInstructions
+    //     );
+    // }
+
+    // /**
+    //  * [REVERT] Should revert because mintData is invalid
+    //  */
+    // function testCannotMintWithInvalidPayload() public {
+    //     (
+    //         ITradeIssuerV2.ContractCallInstruction[] memory _contractCallInstructions,
+    //         uint256 _maxPayAmount
+    //     ) = abi.decode(res, (ITradeIssuerV2.ContractCallInstruction[], uint256));
+    //     mintData = IGasworks.MintChamberData(
+    //         AAGG,
+    //         IIssuerWizard(0x60F56236CD3C1Ac146BD94F2006a1335BaA4c449),
+    //         USDC,
+    //         _maxPayAmount,
+    //         amountToMint
+    //     );
+
+    //     _contractCallInstructions[0]._callData = bytes("bad data");
+
+    //     SigUtils.Permit memory permit = SigUtils.Permit({
+    //         owner: owner,
+    //         spender: address(gasworks),
+    //         value: mintData._maxPayAmount,
+    //         nonce: nonce,
+    //         deadline: 2 ** 256 - 1
+    //     });
+
+    //     bytes32 digest = sigUtils.getTypedDataHash(permit);
+
+    //     (uint8 v, bytes32 r, bytes32 s) = vm.sign(ownerPrivateKey, digest);
+
+    //     vm.expectRevert();
+    //     gasworks.mintChamberWithPermit(
+    //         IGasworks.PermitData(
+    //             address(USDC),
+    //             mintData._maxPayAmount,
+    //             permit.owner,
+    //             permit.spender,
+    //             permit.value,
+    //             permit.deadline,
+    //             v,
+    //             r,
+    //             s
+    //         ),
+    //         mintData,
+    //         _contractCallInstructions
+    //     );
+    // }
+
+    // /**
+    //  * [REVERT] Should revert because token is not permitted
+    //  */
+    // function testCannotMintWithInvalidToken() public {
+    //     (
+    //         ITradeIssuerV2.ContractCallInstruction[] memory _contractCallInstructions,
+    //         uint256 _maxPayAmount
+    //     ) = abi.decode(res, (ITradeIssuerV2.ContractCallInstruction[], uint256));
+    //     mintData = IGasworks.MintChamberData(
+    //         AAGG,
+    //         IIssuerWizard(0x60F56236CD3C1Ac146BD94F2006a1335BaA4c449),
+    //         USDC,
+    //         _maxPayAmount,
+    //         amountToMint
+    //     );
+
+    //     SigUtils.Permit memory permit = SigUtils.Permit({
+    //         owner: owner,
+    //         spender: address(gasworks),
+    //         value: 1e6,
+    //         nonce: nonce,
+    //         deadline: 2 ** 256 - 1
+    //     });
+
+    //     bytes32 digest = sigUtils.getTypedDataHash(permit);
+
+    //     (uint8 v, bytes32 r, bytes32 s) = vm.sign(ownerPrivateKey, digest);
+
+    //     vm.expectRevert(abi.encodeWithSelector(IGasworks.InvalidToken.selector, address(0x123123)));
+    //     gasworks.mintChamberWithPermit(
+    //         IGasworks.PermitData(
+    //             address(0x123123),
+    //             1e6,
+    //             permit.owner,
+    //             permit.spender,
+    //             permit.value,
+    //             permit.deadline,
+    //             v,
+    //             r,
+    //             s
+    //         ),
+    //         mintData,
+    //         _contractCallInstructions
+    //     );
+    // }
+
+    // /*//////////////////////////////////////////////////////////////
+    //                           SUCCESS
+    // //////////////////////////////////////////////////////////////*/
+
+    // /**
+    //  * [SUCCESS] Should make a mint of AAGG with USDC using EIP2612 permit
+    //  */
+    // function testMintChamberWithMaxPermit() public {
+    //     (
+    //         ITradeIssuerV2.ContractCallInstruction[] memory _contractCallInstructions,
+    //         uint256 _maxPayAmount
+    //     ) = abi.decode(res, (ITradeIssuerV2.ContractCallInstruction[], uint256));
+    //     mintData = IGasworks.MintChamberData(
+    //         AAGG,
+    //         IIssuerWizard(0x60F56236CD3C1Ac146BD94F2006a1335BaA4c449),
+    //         USDC,
+    //         _maxPayAmount,
+    //         amountToMint
+    //     );
+
+    //     SigUtils.Permit memory permit = SigUtils.Permit({
+    //         owner: owner,
+    //         spender: address(gasworks),
+    //         value: type(uint256).max,
+    //         nonce: nonce,
+    //         deadline: 2 ** 256 - 1
+    //     });
+
+    //     bytes32 digest = sigUtils.getTypedDataHash(permit);
+
+    //     (uint8 v, bytes32 r, bytes32 s) = vm.sign(ownerPrivateKey, digest);
+
+    //     gasworks.mintChamberWithPermit(
+    //         IGasworks.PermitData(
+    //             address(USDC),
+    //             mintData._maxPayAmount,
+    //             permit.owner,
+    //             permit.spender,
+    //             permit.value,
+    //             permit.deadline,
+    //             v,
+    //             r,
+    //             s
+    //         ),
+    //         mintData,
+    //         _contractCallInstructions
+    //     );
+
+    //     assertEq(USDC.balanceOf(address(gasworks)), 0);
+    //     assertEq(USDC.allowance(owner, address(gasworks)), 0);
+    //     assertEq(IERC20Permit(address(USDC)).nonces(owner), 1);
+    //     assertEq(IERC20(address(AAGG)).balanceOf(owner), amountToMint);
+    // }
+}


### PR DESCRIPTION
# Motivation

Closes #18 

# Summary
Allows the smart contract to mint chambers using normal EIP2612 permits (USDC)

Requires https://github.com/arch-protocol/backend/pull/1402
