### PR TITLE
🔥  Remove Witness and change to permitTransferFrom

### DIFF
--- a/src/Gasworks.sol
+++ b/src/Gasworks.sol
@@ -254,26 +254,23 @@ contract Gasworks is IGasworks, ERC2771Recipient, Owned {
      * Using a permit for the ERC20 token transfer (through Permit2)
      *
      * @param permit2             Permit2 data of the ERC20 token used
-     * @param transferDetails     Details of the transfer to perform
      * @param owner               Owner of the tokens to transfer
-     * @param witness             Payload of data we want to validate (encoded in bytes32)
      * @param signature           Signature of the owner of the tokens
      * @param swapData            Data of the swap to perform
      */
     function swapWithPermit2(
         ISignatureTransfer.PermitTransferFrom memory permit2,
-        ISignatureTransfer.SignatureTransferDetails calldata transferDetails,
         address owner,
-        bytes32 witness,
         bytes calldata signature,
         SwapData calldata swapData
     ) external {
         if (!tokens[permit2.permitted.token]) revert InvalidToken(permit2.permitted.token);
         if (!tokens[swapData.buyToken]) revert InvalidToken(swapData.buyToken);
 
-        signatureTransfer.permitWitnessTransferFrom(
-            permit2, transferDetails, owner, witness, SWAPDATA_WITNESS_TYPE_STRING, signature
-        );
+        ISignatureTransfer.SignatureTransferDetails memory transferDetails = ISignatureTransfer
+            .SignatureTransferDetails({ to: address(this), requestedAmount: permit2.permitted.amount });
+
+        signatureTransfer.permitTransferFrom(permit2, transferDetails, owner, signature);
 
         _fillQuoteInternal(
             swapData, transferDetails.requestedAmount, owner, ERC20(permit2.permitted.token)
@@ -285,18 +282,14 @@ contract Gasworks is IGasworks, ERC2771Recipient, Owned {
      * Using a permit for the ERC20 token (through Permit2)
      *
      * @param permit2                       Permit2 data of the ERC20 token used
-     * @param transferDetails               Details of the transfer to perform
      * @param owner                         Owner of the tokens to transfer
-     * @param witness                       Payload of data we want to validate (encoded in bytes32)
      * @param signature                     Signature of the owner of the tokens
      * @param mintChamberData               Data of the chamber issuance to perform
      * @param contractCallInstructions      Calls required to get all chamber components
      */
     function mintChamberWithPermit2(
         ISignatureTransfer.PermitTransferFrom memory permit2,
-        ISignatureTransfer.SignatureTransferDetails calldata transferDetails,
         address owner,
-        bytes32 witness,
         bytes calldata signature,
         MintChamberData calldata mintChamberData,
         ITradeIssuerV2.ContractCallInstruction[] memory contractCallInstructions
@@ -306,9 +299,10 @@ contract Gasworks is IGasworks, ERC2771Recipient, Owned {
             revert InvalidToken(address(mintChamberData._chamber));
         }
 
-        signatureTransfer.permitWitnessTransferFrom(
-            permit2, transferDetails, owner, witness, MINT_CHAMBER_WITNESS_TYPE_STRING, signature
-        );
+        ISignatureTransfer.SignatureTransferDetails memory transferDetails = ISignatureTransfer
+            .SignatureTransferDetails({ to: address(this), requestedAmount: permit2.permitted.amount });
+
+        signatureTransfer.permitTransferFrom(permit2, transferDetails, owner, signature);
 
         ERC20 token = ERC20(permit2.permitted.token);
         uint256 beforeBalance = token.balanceOf(address(this));
@@ -342,18 +336,14 @@ contract Gasworks is IGasworks, ERC2771Recipient, Owned {
      * Using a permit for the Chamber token (through Permit2)
      *
      * @param permit2                       Permit2 data of the ERC20 token used
-     * @param transferDetails               Details of the transfer to perform
      * @param owner                         Owner of the tokens to transfer
-     * @param witness                       Payload of data we want to validate (encoded in bytes32)
      * @param signature                     Signature of the owner of the tokens
      * @param redeemChamberData             Data of the chamber redeem to perform
      * @param contractCallInstructions      Calls required to get all chamber components
      */
     function redeemChamberWithPermit2(
         ISignatureTransfer.PermitTransferFrom memory permit2,
-        ISignatureTransfer.SignatureTransferDetails calldata transferDetails,
         address owner,
-        bytes32 witness,
         bytes calldata signature,
         RedeemChamberData calldata redeemChamberData,
         ITradeIssuerV2.ContractCallInstruction[] memory contractCallInstructions,
@@ -364,9 +354,10 @@ contract Gasworks is IGasworks, ERC2771Recipient, Owned {
             revert InvalidToken(address(redeemChamberData._baseToken));
         }
 
-        signatureTransfer.permitWitnessTransferFrom(
-            permit2, transferDetails, owner, witness, REDEEM_CHAMBER_WITNESS_TYPE_STRING, signature
-        );
+        ISignatureTransfer.SignatureTransferDetails memory transferDetails = ISignatureTransfer
+            .SignatureTransferDetails({ to: address(this), requestedAmount: permit2.permitted.amount });
+
+        signatureTransfer.permitTransferFrom(permit2, transferDetails, owner, signature);
 
         ERC20 token = ERC20(permit2.permitted.token);
 

--- a/src/interfaces/IGasworks.sol
+++ b/src/interfaces/IGasworks.sol
@@ -174,18 +174,14 @@ interface IGasworks {
 
     function swapWithPermit2(
         ISignatureTransfer.PermitTransferFrom memory permit2,
-        ISignatureTransfer.SignatureTransferDetails calldata transferDetails,
         address owner,
-        bytes32 witness,
         bytes calldata signature,
         SwapData calldata swapData
     ) external;
 
     function mintChamberWithPermit2(
         ISignatureTransfer.PermitTransferFrom memory permit2,
-        ISignatureTransfer.SignatureTransferDetails calldata transferDetails,
         address owner,
-        bytes32 witness,
         bytes calldata signature,
         MintChamberData calldata mintChamberData,
         ITradeIssuerV2.ContractCallInstruction[] memory contractCallInstructions
@@ -193,9 +189,7 @@ interface IGasworks {
 
     function redeemChamberWithPermit2(
         ISignatureTransfer.PermitTransferFrom memory permit2,
-        ISignatureTransfer.SignatureTransferDetails calldata transferDetails,
         address owner,
-        bytes32 witness,
         bytes calldata signature,
         RedeemChamberData calldata redeemChamberData,
         ITradeIssuerV2.ContractCallInstruction[] memory contractCallInstructions,

--- a/test/utils/Permit2Utils.sol
+++ b/test/utils/Permit2Utils.sol
@@ -5,21 +5,17 @@ import { Test } from "forge-std/Test.sol";
 import { ISignatureTransfer } from "permit2/src/interfaces/ISignatureTransfer.sol";
 
 contract Permit2Utils is Test {
-    function getTransferDetails(address to, uint256 amount)
-        internal
-        pure
-        returns (ISignatureTransfer.SignatureTransferDetails memory)
-    {
-        return ISignatureTransfer.SignatureTransferDetails({ to: to, requestedAmount: amount });
-    }
+    bytes32 public constant _PERMIT_TRANSFER_FROM_TYPEHASH = keccak256(
+        "PermitTransferFrom(TokenPermissions permitted,address spender,uint256 nonce,uint256 deadline)TokenPermissions(address token,uint256 amount)"
+    );
 
-    function defaultERC20PermitTransfer(address token0, uint256 nonce)
+    function defaultERC20PermitTransfer(address token0, uint256 nonce, uint256 requestedAmount)
         internal
         pure
         returns (ISignatureTransfer.PermitTransferFrom memory)
     {
         return ISignatureTransfer.PermitTransferFrom({
-            permitted: ISignatureTransfer.TokenPermissions({ token: token0, amount: 10 ** 18 }),
+            permitted: ISignatureTransfer.TokenPermissions({ token: token0, amount: requestedAmount }),
             nonce: nonce,
             deadline: 2 ** 256 - 1
         });
@@ -28,21 +24,22 @@ contract Permit2Utils is Test {
     function getSignature(
         ISignatureTransfer.PermitTransferFrom memory permit,
         uint256 privateKey,
-        bytes32 typehash,
-        bytes32 witness,
         bytes32 domainSeparator,
         bytes32 tokenPermissionsHash,
         address caller
-    ) internal returns (bytes memory signature) {
+    ) internal pure returns (bytes memory signature) {
         bytes32 tokenPermissions = keccak256(abi.encode(tokenPermissionsHash, permit.permitted));
-
         bytes32 msgHash = keccak256(
             abi.encodePacked(
                 "\x19\x01",
                 domainSeparator,
                 keccak256(
                     abi.encode(
-                        typehash, tokenPermissions, caller, permit.nonce, permit.deadline, witness
+                        _PERMIT_TRANSFER_FROM_TYPEHASH,
+                        tokenPermissions,
+                        caller,
+                        permit.nonce,
+                        permit.deadline
                     )
                 )
             )


### PR DESCRIPTION
# Motivation

I was completely unable to make a frontend signature that could recover the owner address using a Witness, therefore instead of spending more hours trying in that front, i succedeed in using signature that do not require the witness. Therefore, we shall follow that route

# Summary
- Remove `witness` param from the contract interactions
- Move `transferDetails` into each function
- Adapt each test for these changes
- Change the `getSignature` util function to sign without using a witness