### PR TITLE
:rocket: Swap with Permit2 and witness

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "axios": "^1.3.5",
         "ethers": "^6.3.0",
+        "http-status-codes": "^2.2.0",
         "jose": "^4.14.0",
         "qs": "^6.11.1",
         "solhint": "^3.4.1",
@@ -500,6 +501,11 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/http-status-codes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/http-status-codes/-/http-status-codes-2.2.0.tgz",
+      "integrity": "sha512-feERVo9iWxvnejp3SEfm/+oNG517npqL2/PIA8ORjyOZjGC7TwCRQsZylciLS64i6pJ0wRYz3rkXLRwbtFa8Ng=="
     },
     "node_modules/ignore": {
       "version": "5.2.4",
@@ -1357,6 +1363,11 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
       "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A=="
+    },
+    "http-status-codes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/http-status-codes/-/http-status-codes-2.2.0.tgz",
+      "integrity": "sha512-feERVo9iWxvnejp3SEfm/+oNG517npqL2/PIA8ORjyOZjGC7TwCRQsZylciLS64i6pJ0wRYz3rkXLRwbtFa8Ng=="
     },
     "ignore": {
       "version": "5.2.4",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "",
   "main": "index.js",
+  "type": "module",
   "directories": {
     "lib": "lib",
     "test": "test"
@@ -23,6 +24,7 @@
   "dependencies": {
     "axios": "^1.3.5",
     "ethers": "^6.3.0",
+    "http-status-codes": "^2.2.0",
     "jose": "^4.14.0",
     "qs": "^6.11.1",
     "solhint": "^3.4.1",

--- a/scripts/config.js
+++ b/scripts/config.js
@@ -38,6 +38,4 @@ const archTokens = {
   "0xAfb6E8331355faE99C8E8953bB4c6Dc5d11E9F3c": AAGGTokenParams,
 }
 
-module.exports = {
-  archTokens
-}
+export {archTokens};

--- a/scripts/fetch-arch-quote.js
+++ b/scripts/fetch-arch-quote.js
@@ -1,11 +1,10 @@
-const { ethers } = require("ethers")
-const axios = require("axios").default
+import { ethers } from "ethers";
+import qs from "qs";
+import {get} from './get.js';
+import { SignJWT } from "jose";
+import { archTokens } from "./config.js";
+
 const encoder = new ethers.AbiCoder()
-const qs = require("qs")
-const {
-  SignJWT,
-} = require('jose');
-const { archTokens } = require('../config')
 
 async function generateJwt(payload) {
   const privateKey = Buffer.from("dev-jwt-secret-key");
@@ -15,11 +14,13 @@ async function generateJwt(payload) {
   return jwt;
 }
 
+const issuance = '0x0000000000000000000000000000000000000000000000000000000000000000';
+
 async function main(quantity, basketAddress, tokenAddress, operation) {
   const qty = encoder.decode(["uint256"], quantity)[0]
   const basket = encoder.decode(["address"], basketAddress)[0]
   const token = encoder.decode(["address"], tokenAddress)[0]
-  const opt = encoder.decode(["bool"], operation)[0]
+  const opt = operation === issuance;
 
   archTokens[basket].basketAmountInWei = qty.toString()
   archTokens[basket].tokenAddress = token
@@ -30,7 +31,7 @@ async function main(quantity, basketAddress, tokenAddress, operation) {
     archTokens[basket]
   )}`
   try {
-    const response = await axios.get(quoteUrl, {
+    const response = await get(quoteUrl, {
       headers: { Authorization: `Bearer ${jwt}` },
     });
 
@@ -38,7 +39,7 @@ async function main(quantity, basketAddress, tokenAddress, operation) {
     const value = opt ? quote.maxAmountInWei : quote.minAmountInWei
     const data = quote.callInstructions ? quote.callInstructions : quote.encodedComponentQuotes
     const encodedType = quote.callInstructions ? "tuple(address target, address allowanceTarget, address sellToken, uint256 sellAmount, address buyToken, uint256 minBuyAmount, bytes callData)[]" : "bytes[]"
-    encoded = encoder.encode([encodedType, "uint256"], [data, value])
+    const encoded = encoder.encode([encodedType, "uint256"], [data, value])
 
     process.stdout.write(encoded)
   } catch (error) {

--- a/scripts/fetch-quote.js
+++ b/scripts/fetch-quote.js
@@ -1,5 +1,5 @@
-const { ethers } = require("ethers")
-const axios = require("axios").default
+import { ethers } from "ethers";
+import {get} from './get.js';
 const encoder = new ethers.AbiCoder();
 
 const API_QUOTE_URL = "https://polygon.api.0x.org/swap/v1/quote"
@@ -22,10 +22,10 @@ async function main(quantity, buyToken) {
   })
 
   let quoteUrl = `${API_QUOTE_URL}?${qs}`
-  let response = await axios.get(quoteUrl)
+  let response = await get(quoteUrl, { headers: {"0x-api-key": '05f12b06-3c41-440e-9357-6c5155bd4a43'}})
   let quote = response.data
 
-  encoded = encoder.encode(["address", "address",
+  const encoded = encoder.encode(["address", "address",
     "bytes", "uint256", "uint256"], [quote.allowanceTarget, quote.to, quote.data, quote.value, quote.buyAmount]);
   process.stdout.write(encoded)
 }

--- a/scripts/get.js
+++ b/scripts/get.js
@@ -1,0 +1,70 @@
+import { StatusCodes } from 'http-status-codes';
+import axios from 'axios';
+
+/**
+ * Generic get function using axios. Headers go inside options. If {retryResponse} is true,
+ * axios will try to request again.
+ *
+ * @param url           The complete url to be requested
+ * @param options       Headers and other oprtions passed to axios
+ * @param retryResponse If true, will retry the request
+ *
+ * @returns The api response
+ */
+export async function get(
+  url,
+  options,
+  retryResponse = false,
+) {
+  try {
+    const api = axios.create();
+    if (retryResponse) {
+      const maxRetryCount = 2;
+      let currentRetryCount = 0;
+
+      const retryRequest = async (
+        error,
+      ) => {
+        const {
+          config: originalRequest,
+          response: { status },
+        } = error;
+
+        if (!originalRequest || currentRetryCount >= maxRetryCount) {
+          return Promise.reject(error);
+        }
+        currentRetryCount += 1;
+
+        if (status && (
+          status === StatusCodes.TOO_MANY_REQUESTS
+          || status === StatusCodes.INTERNAL_SERVER_ERROR
+        )) {
+          const delayRetryRequest = new Promise((resolve) => {
+            setTimeout(() => {
+              resolve();
+            }, 1000);
+          });
+          return delayRetryRequest.then(() => axios(originalRequest));
+        }
+
+        throw error;
+      };
+
+      api.interceptors.response.use(
+        (response ) => response,
+        (error) => retryRequest(error),
+      );
+    }
+
+    const response = await api
+      .get(url, options);
+    const { headers, data } = response;
+    return { headers, data };
+  } catch (error) {
+    const {
+      status,
+      data,
+    } = error.response;
+    throw new Error(data);
+  }
+}

--- a/src/Gasworks.sol
+++ b/src/Gasworks.sol
@@ -66,11 +66,6 @@ contract Gasworks is IGasworks, ERC2771Recipient, Owned {
     ISignatureTransfer public immutable signatureTransfer;
     ITradeIssuerV2 public immutable tradeIssuer;
 
-    bytes private constant SWAP_DATA_TYPE = "SwapData(address buyToken,address spender,address swapTarget,bytes swapCallData,uint256 swapValue,uint256 buyAmount)";
-    bytes private constant TOKEN_PERMISSIONS_TYPE = "TokenPermissions(address token,uint256 amount)";
-    string internal constant PERMIT2_SWAP_DATA_TYPE = string(abi.encodePacked("SwapData witness)", SWAP_DATA_TYPE, TOKEN_PERMISSIONS_TYPE));
-    ///
-    
     string private constant SWAPDATA_WITNESS_TYPE_STRING =
         "SwapData witness)SwapData(address buyToken,address spender,address payable swapTarget, bytes swapCallData,uint256 swapValue,uint256 buyAmount)TokenPermissions(address token,uint256 amount)";
 
@@ -275,23 +270,7 @@ contract Gasworks is IGasworks, ERC2771Recipient, Owned {
         ISignatureTransfer.SignatureTransferDetails memory transferDetails = ISignatureTransfer
             .SignatureTransferDetails({ to: address(this), requestedAmount: permit2.permitted.amount });
 
-        bytes32 witness = keccak256(abi.encode(
-          keccak256(abi.encodePacked(SWAP_DATA_TYPE)),
-          swapData.buyToken,
-          swapData.spender,
-          swapData.swapTarget,
-          keccak256(swapData.swapCallData),
-          swapData.swapValue,
-          swapData.buyAmount
-        ));
-
-        signatureTransfer.permitWitnessTransferFrom(
-          permit2,
-          transferDetails,
-          owner,
-          witness,
-          PERMIT2_SWAP_DATA_TYPE,
-          signature);
+        signatureTransfer.permitTransferFrom(permit2, transferDetails, owner, signature);
 
         _fillQuoteInternal(
             swapData, transferDetails.requestedAmount, owner, ERC20(permit2.permitted.token)

--- a/src/Gasworks.sol
+++ b/src/Gasworks.sol
@@ -66,6 +66,11 @@ contract Gasworks is IGasworks, ERC2771Recipient, Owned {
     ISignatureTransfer public immutable signatureTransfer;
     ITradeIssuerV2 public immutable tradeIssuer;
 
+    bytes private constant SWAP_DATA_TYPE = "SwapData(address buyToken,address spender,address swapTarget,bytes swapCallData,uint256 swapValue,uint256 buyAmount)";
+    bytes private constant TOKEN_PERMISSIONS_TYPE = "TokenPermissions(address token,uint256 amount)";
+    string internal constant PERMIT2_SWAP_DATA_TYPE = string(abi.encodePacked("SwapData witness)", SWAP_DATA_TYPE, TOKEN_PERMISSIONS_TYPE));
+    ///
+    
     string private constant SWAPDATA_WITNESS_TYPE_STRING =
         "SwapData witness)SwapData(address buyToken,address spender,address payable swapTarget, bytes swapCallData,uint256 swapValue,uint256 buyAmount)TokenPermissions(address token,uint256 amount)";
 
@@ -270,7 +275,23 @@ contract Gasworks is IGasworks, ERC2771Recipient, Owned {
         ISignatureTransfer.SignatureTransferDetails memory transferDetails = ISignatureTransfer
             .SignatureTransferDetails({ to: address(this), requestedAmount: permit2.permitted.amount });
 
-        signatureTransfer.permitTransferFrom(permit2, transferDetails, owner, signature);
+        bytes32 witness = keccak256(abi.encode(
+          keccak256(abi.encodePacked(SWAP_DATA_TYPE)),
+          swapData.buyToken,
+          swapData.spender,
+          swapData.swapTarget,
+          keccak256(swapData.swapCallData),
+          swapData.swapValue,
+          swapData.buyAmount
+        ));
+
+        signatureTransfer.permitWitnessTransferFrom(
+          permit2,
+          transferDetails,
+          owner,
+          witness,
+          PERMIT2_SWAP_DATA_TYPE,
+          signature);
 
         _fillQuoteInternal(
             swapData, transferDetails.requestedAmount, owner, ERC20(permit2.permitted.token)

--- a/test/permit2/Chambers/mintChamberWithPermit2.t.sol
+++ b/test/permit2/Chambers/mintChamberWithPermit2.t.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.17.0;
 import { Test } from "forge-std/Test.sol";
 import { Gasworks } from "src/Gasworks.sol";
 import { IGasworks } from "src/interfaces/IGasworks.sol";
+import { ERC20 } from "solmate/src/tokens/ERC20.sol";
 import { IERC20 } from "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
 import { SafeERC20 } from "openzeppelin-contracts/contracts/token/ERC20/utils/SafeERC20.sol";
 import { Conversor } from "test/utils/HexUtils.sol";
@@ -37,7 +38,7 @@ contract GaslessTest is Test, Permit2Utils, ChamberTestUtils, DeployPermit2 {
     bytes32 internal domainSeparator;
     address internal permit2;
     bytes internal res;
-    uint256 internal amountToMint = 10e18;
+    uint256 internal amountToMint = 100e18;
 
     /*//////////////////////////////////////////////////////////////
                               SET UP
@@ -65,8 +66,7 @@ contract GaslessTest is Test, Permit2Utils, ChamberTestUtils, DeployPermit2 {
         inputs[5] = Conversor.iToHex(abi.encode(true));
         res = vm.ffi(inputs);
 
-        vm.prank(0x0A59649758aa4d66E25f08Dd01271e891fe52199);
-        USDC.safeTransfer(owner, 150e6);
+        deal(address(USDC), owner, 1500e6);
 
         vm.prank(owner);
         USDC.approve(permit2, type(uint256).max);
@@ -92,8 +92,9 @@ contract GaslessTest is Test, Permit2Utils, ChamberTestUtils, DeployPermit2 {
             amountToMint
         );
 
+        uint256 currentNonce = ERC20(address(USDC)).nonces(owner);
         ISignatureTransfer.PermitTransferFrom memory permit =
-            defaultERC20PermitTransfer(address(USDC), 0, _maxPayAmount);
+            defaultERC20PermitTransfer(address(USDC), currentNonce, _maxPayAmount);
         bytes memory signature = getSignature(
             permit, ownerPrivateKey, domainSeparator, TOKEN_PERMISSIONS_TYPEHASH, address(gasworks)
         );
@@ -122,8 +123,9 @@ contract GaslessTest is Test, Permit2Utils, ChamberTestUtils, DeployPermit2 {
             amountToMint
         );
 
+        uint256 currentNonce = ERC20(address(USDC)).nonces(owner);
         ISignatureTransfer.PermitTransferFrom memory permit =
-            defaultERC20PermitTransfer(address(USDC), 0, _maxPayAmount);
+            defaultERC20PermitTransfer(address(USDC), currentNonce, _maxPayAmount);
         bytes memory signature = getSignature(
             permit, ownerPrivateKey, domainSeparator, TOKEN_PERMISSIONS_TYPEHASH, address(gasworks)
         );
@@ -154,8 +156,9 @@ contract GaslessTest is Test, Permit2Utils, ChamberTestUtils, DeployPermit2 {
             amountToMint
         );
 
+        uint256 currentNonce = ERC20(address(USDC)).nonces(owner);
         ISignatureTransfer.PermitTransferFrom memory permit =
-            defaultERC20PermitTransfer(address(USDC), 0, _maxPayAmount);
+            defaultERC20PermitTransfer(address(USDC), currentNonce, _maxPayAmount);
         permit.deadline = 2 ** 255 - 1;
         bytes memory signature = getSignature(
             permit, ownerPrivateKey, domainSeparator, TOKEN_PERMISSIONS_TYPEHASH, address(gasworks)
@@ -187,8 +190,9 @@ contract GaslessTest is Test, Permit2Utils, ChamberTestUtils, DeployPermit2 {
 
         _contractCallInstructions[0]._callData = bytes("bad data");
 
+        uint256 currentNonce = ERC20(address(USDC)).nonces(owner);
         ISignatureTransfer.PermitTransferFrom memory permit =
-            defaultERC20PermitTransfer(address(USDC), 0, _maxPayAmount);
+            defaultERC20PermitTransfer(address(USDC), currentNonce, _maxPayAmount);
         bytes memory signature = getSignature(
             permit, ownerPrivateKey, domainSeparator, TOKEN_PERMISSIONS_TYPEHASH, address(gasworks)
         );
@@ -215,8 +219,9 @@ contract GaslessTest is Test, Permit2Utils, ChamberTestUtils, DeployPermit2 {
             amountToMint
         );
 
+        uint256 currentNonce = ERC20(address(USDC)).nonces(owner);
         ISignatureTransfer.PermitTransferFrom memory permit =
-            defaultERC20PermitTransfer(0x8f3Cf7ad23Cd3CaDbD9735AFf958023239c6A063, 0, 1e1);
+            defaultERC20PermitTransfer(0x8f3Cf7ad23Cd3CaDbD9735AFf958023239c6A063, currentNonce, 1e1);
         bytes memory signature = getSignature(
             permit, ownerPrivateKey, domainSeparator, TOKEN_PERMISSIONS_TYPEHASH, address(gasworks)
         );
@@ -251,8 +256,9 @@ contract GaslessTest is Test, Permit2Utils, ChamberTestUtils, DeployPermit2 {
             amountToMint
         );
 
+        uint256 currentNonce = ERC20(address(USDC)).nonces(owner);
         ISignatureTransfer.PermitTransferFrom memory permit =
-            defaultERC20PermitTransfer(address(USDC), 0, _maxPayAmount);
+            defaultERC20PermitTransfer(address(USDC), currentNonce, _maxPayAmount);
         bytes memory signature = getSignature(
             permit, ownerPrivateKey, domainSeparator, TOKEN_PERMISSIONS_TYPEHASH, address(gasworks)
         );

--- a/test/permit2/Chambers/mintChamberWithPermit2.t.sol
+++ b/test/permit2/Chambers/mintChamberWithPermit2.t.sol
@@ -4,7 +4,6 @@ pragma solidity ^0.8.17.0;
 import { Test } from "forge-std/Test.sol";
 import { Gasworks } from "src/Gasworks.sol";
 import { IGasworks } from "src/interfaces/IGasworks.sol";
-import { ERC20 } from "solmate/src/tokens/ERC20.sol";
 import { IERC20 } from "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
 import { SafeERC20 } from "openzeppelin-contracts/contracts/token/ERC20/utils/SafeERC20.sol";
 import { Conversor } from "test/utils/HexUtils.sol";
@@ -38,7 +37,7 @@ contract GaslessTest is Test, Permit2Utils, ChamberTestUtils, DeployPermit2 {
     bytes32 internal domainSeparator;
     address internal permit2;
     bytes internal res;
-    uint256 internal amountToMint = 100e18;
+    uint256 internal amountToMint = 10e18;
 
     /*//////////////////////////////////////////////////////////////
                               SET UP
@@ -66,7 +65,8 @@ contract GaslessTest is Test, Permit2Utils, ChamberTestUtils, DeployPermit2 {
         inputs[5] = Conversor.iToHex(abi.encode(true));
         res = vm.ffi(inputs);
 
-        deal(address(USDC), owner, 1500e6);
+        vm.prank(0x0A59649758aa4d66E25f08Dd01271e891fe52199);
+        USDC.safeTransfer(owner, 150e6);
 
         vm.prank(owner);
         USDC.approve(permit2, type(uint256).max);
@@ -92,9 +92,8 @@ contract GaslessTest is Test, Permit2Utils, ChamberTestUtils, DeployPermit2 {
             amountToMint
         );
 
-        uint256 currentNonce = ERC20(address(USDC)).nonces(owner);
         ISignatureTransfer.PermitTransferFrom memory permit =
-            defaultERC20PermitTransfer(address(USDC), currentNonce, _maxPayAmount);
+            defaultERC20PermitTransfer(address(USDC), 0, _maxPayAmount);
         bytes memory signature = getSignature(
             permit, ownerPrivateKey, domainSeparator, TOKEN_PERMISSIONS_TYPEHASH, address(gasworks)
         );
@@ -123,9 +122,8 @@ contract GaslessTest is Test, Permit2Utils, ChamberTestUtils, DeployPermit2 {
             amountToMint
         );
 
-        uint256 currentNonce = ERC20(address(USDC)).nonces(owner);
         ISignatureTransfer.PermitTransferFrom memory permit =
-            defaultERC20PermitTransfer(address(USDC), currentNonce, _maxPayAmount);
+            defaultERC20PermitTransfer(address(USDC), 0, _maxPayAmount);
         bytes memory signature = getSignature(
             permit, ownerPrivateKey, domainSeparator, TOKEN_PERMISSIONS_TYPEHASH, address(gasworks)
         );
@@ -156,9 +154,8 @@ contract GaslessTest is Test, Permit2Utils, ChamberTestUtils, DeployPermit2 {
             amountToMint
         );
 
-        uint256 currentNonce = ERC20(address(USDC)).nonces(owner);
         ISignatureTransfer.PermitTransferFrom memory permit =
-            defaultERC20PermitTransfer(address(USDC), currentNonce, _maxPayAmount);
+            defaultERC20PermitTransfer(address(USDC), 0, _maxPayAmount);
         permit.deadline = 2 ** 255 - 1;
         bytes memory signature = getSignature(
             permit, ownerPrivateKey, domainSeparator, TOKEN_PERMISSIONS_TYPEHASH, address(gasworks)
@@ -190,9 +187,8 @@ contract GaslessTest is Test, Permit2Utils, ChamberTestUtils, DeployPermit2 {
 
         _contractCallInstructions[0]._callData = bytes("bad data");
 
-        uint256 currentNonce = ERC20(address(USDC)).nonces(owner);
         ISignatureTransfer.PermitTransferFrom memory permit =
-            defaultERC20PermitTransfer(address(USDC), currentNonce, _maxPayAmount);
+            defaultERC20PermitTransfer(address(USDC), 0, _maxPayAmount);
         bytes memory signature = getSignature(
             permit, ownerPrivateKey, domainSeparator, TOKEN_PERMISSIONS_TYPEHASH, address(gasworks)
         );
@@ -219,9 +215,8 @@ contract GaslessTest is Test, Permit2Utils, ChamberTestUtils, DeployPermit2 {
             amountToMint
         );
 
-        uint256 currentNonce = ERC20(address(USDC)).nonces(owner);
         ISignatureTransfer.PermitTransferFrom memory permit =
-            defaultERC20PermitTransfer(0x8f3Cf7ad23Cd3CaDbD9735AFf958023239c6A063, currentNonce, 1e1);
+            defaultERC20PermitTransfer(0x8f3Cf7ad23Cd3CaDbD9735AFf958023239c6A063, 0, 1e1);
         bytes memory signature = getSignature(
             permit, ownerPrivateKey, domainSeparator, TOKEN_PERMISSIONS_TYPEHASH, address(gasworks)
         );
@@ -256,9 +251,8 @@ contract GaslessTest is Test, Permit2Utils, ChamberTestUtils, DeployPermit2 {
             amountToMint
         );
 
-        uint256 currentNonce = ERC20(address(USDC)).nonces(owner);
         ISignatureTransfer.PermitTransferFrom memory permit =
-            defaultERC20PermitTransfer(address(USDC), currentNonce, _maxPayAmount);
+            defaultERC20PermitTransfer(address(USDC), 0, _maxPayAmount);
         bytes memory signature = getSignature(
             permit, ownerPrivateKey, domainSeparator, TOKEN_PERMISSIONS_TYPEHASH, address(gasworks)
         );

--- a/test/permit2/Chambers/redeemChamberWithPermit2.t.sol
+++ b/test/permit2/Chambers/redeemChamberWithPermit2.t.sol
@@ -4,7 +4,6 @@ pragma solidity ^0.8.17.0;
 import { Test } from "forge-std/Test.sol";
 import { Gasworks } from "src/Gasworks.sol";
 import { IGasworks } from "src/interfaces/IGasworks.sol";
-import { ERC20 } from "solmate/src/tokens/ERC20.sol";
 import { IERC20 } from "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
 import { SafeERC20 } from "openzeppelin-contracts/contracts/token/ERC20/utils/SafeERC20.sol";
 import { Conversor } from "test/utils/HexUtils.sol";
@@ -40,6 +39,7 @@ contract GaslessTest is Test, Permit2Utils, ChamberTestUtils, DeployPermit2 {
     bytes32 internal domainSeparator;
     address internal permit2;
     bytes internal res;
+    uint256 internal nonce = 0;
     uint256 internal amountToRedeem = 1e18;
 
     /*//////////////////////////////////////////////////////////////
@@ -95,9 +95,8 @@ contract GaslessTest is Test, Permit2Utils, ChamberTestUtils, DeployPermit2 {
             _minOutputReceive,
             amountToRedeem
         );
-        uint256 currentNonce = ERC20(address(USDC)).nonces(owner);
         ISignatureTransfer.PermitTransferFrom memory permit =
-            defaultERC20PermitTransfer(address(ADDY), currentNonce, amountToRedeem);
+            defaultERC20PermitTransfer(address(ADDY), nonce, amountToRedeem);
         bytes memory signature = getSignature(
             permit, ownerPrivateKey, domainSeparator, TOKEN_PERMISSIONS_TYPEHASH, address(gasworks)
         );
@@ -125,9 +124,8 @@ contract GaslessTest is Test, Permit2Utils, ChamberTestUtils, DeployPermit2 {
             _minOutputReceive,
             amountToRedeem
         );
-        uint256 currentNonce = ERC20(address(USDC)).nonces(owner);
         ISignatureTransfer.PermitTransferFrom memory permit =
-            defaultERC20PermitTransfer(address(ADDY), currentNonce, amountToRedeem);
+            defaultERC20PermitTransfer(address(ADDY), nonce, amountToRedeem);
         bytes memory signature = getSignature(
             permit, ownerPrivateKey, domainSeparator, TOKEN_PERMISSIONS_TYPEHASH, address(gasworks)
         );
@@ -157,9 +155,8 @@ contract GaslessTest is Test, Permit2Utils, ChamberTestUtils, DeployPermit2 {
             _minOutputReceive,
             amountToRedeem
         );
-        uint256 currentNonce = ERC20(address(USDC)).nonces(owner);
         ISignatureTransfer.PermitTransferFrom memory permit =
-            defaultERC20PermitTransfer(address(ADDY), currentNonce, amountToRedeem);
+            defaultERC20PermitTransfer(address(ADDY), nonce, amountToRedeem);
         permit.deadline = 2 ** 255 - 1;
         bytes memory signature = getSignature(
             permit, ownerPrivateKey, domainSeparator, TOKEN_PERMISSIONS_TYPEHASH, address(gasworks)
@@ -188,9 +185,8 @@ contract GaslessTest is Test, Permit2Utils, ChamberTestUtils, DeployPermit2 {
             _minOutputReceive,
             amountToRedeem
         );
-        uint256 currentNonce = ERC20(address(USDC)).nonces(owner);
         ISignatureTransfer.PermitTransferFrom memory permit =
-            defaultERC20PermitTransfer(address(ADDY), currentNonce, amountToRedeem);
+            defaultERC20PermitTransfer(address(ADDY), nonce, amountToRedeem);
         bytes memory signature = getSignature(
             permit, ownerPrivateKey, domainSeparator, TOKEN_PERMISSIONS_TYPEHASH, address(gasworks)
         );
@@ -224,9 +220,8 @@ contract GaslessTest is Test, Permit2Utils, ChamberTestUtils, DeployPermit2 {
             _minOutputReceive,
             amountToRedeem
         );
-        uint256 currentNonce = ERC20(address(USDC)).nonces(owner);
         ISignatureTransfer.PermitTransferFrom memory permit =
-            defaultERC20PermitTransfer(address(ADDY), currentNonce, amountToRedeem);
+            defaultERC20PermitTransfer(address(ADDY), nonce, amountToRedeem);
         bytes memory signature = getSignature(
             permit, ownerPrivateKey, domainSeparator, TOKEN_PERMISSIONS_TYPEHASH, address(gasworks)
         );
@@ -260,9 +255,8 @@ contract GaslessTest is Test, Permit2Utils, ChamberTestUtils, DeployPermit2 {
             _minOutputReceive,
             amountToRedeem
         );
-        uint256 currentNonce = ERC20(address(USDC)).nonces(owner);
         ISignatureTransfer.PermitTransferFrom memory permit =
-            defaultERC20PermitTransfer(address(ADDY), currentNonce, amountToRedeem);
+            defaultERC20PermitTransfer(address(ADDY), nonce, amountToRedeem);
         bytes memory signature = getSignature(
             permit, ownerPrivateKey, domainSeparator, TOKEN_PERMISSIONS_TYPEHASH, address(gasworks)
         );
@@ -297,9 +291,8 @@ contract GaslessTest is Test, Permit2Utils, ChamberTestUtils, DeployPermit2 {
             amountToRedeem
         );
 
-        uint256 currentNonce = ERC20(address(USDC)).nonces(owner);
         ISignatureTransfer.PermitTransferFrom memory permit =
-            defaultERC20PermitTransfer(address(ADDY), currentNonce, amountToRedeem);
+            defaultERC20PermitTransfer(address(ADDY), nonce, amountToRedeem);
         bytes memory signature = getSignature(
             permit, ownerPrivateKey, domainSeparator, TOKEN_PERMISSIONS_TYPEHASH, address(gasworks)
         );
@@ -334,9 +327,8 @@ contract GaslessTest is Test, Permit2Utils, ChamberTestUtils, DeployPermit2 {
             amountToRedeem
         );
 
-        uint256 currentNonce = ERC20(address(USDC)).nonces(owner);
         ISignatureTransfer.PermitTransferFrom memory permit =
-            defaultERC20PermitTransfer(address(ADDY), currentNonce, amountToRedeem);
+            defaultERC20PermitTransfer(address(ADDY), nonce, amountToRedeem);
         bytes memory signature = getSignature(
             permit, ownerPrivateKey, domainSeparator, TOKEN_PERMISSIONS_TYPEHASH, address(gasworks)
         );

--- a/test/permit2/Chambers/redeemChamberWithPermit2.t.sol
+++ b/test/permit2/Chambers/redeemChamberWithPermit2.t.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.17.0;
 import { Test } from "forge-std/Test.sol";
 import { Gasworks } from "src/Gasworks.sol";
 import { IGasworks } from "src/interfaces/IGasworks.sol";
+import { ERC20 } from "solmate/src/tokens/ERC20.sol";
 import { IERC20 } from "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
 import { SafeERC20 } from "openzeppelin-contracts/contracts/token/ERC20/utils/SafeERC20.sol";
 import { Conversor } from "test/utils/HexUtils.sol";
@@ -39,7 +40,6 @@ contract GaslessTest is Test, Permit2Utils, ChamberTestUtils, DeployPermit2 {
     bytes32 internal domainSeparator;
     address internal permit2;
     bytes internal res;
-    uint256 internal nonce = 0;
     uint256 internal amountToRedeem = 1e18;
 
     /*//////////////////////////////////////////////////////////////
@@ -95,8 +95,9 @@ contract GaslessTest is Test, Permit2Utils, ChamberTestUtils, DeployPermit2 {
             _minOutputReceive,
             amountToRedeem
         );
+        uint256 currentNonce = ERC20(address(USDC)).nonces(owner);
         ISignatureTransfer.PermitTransferFrom memory permit =
-            defaultERC20PermitTransfer(address(ADDY), nonce, amountToRedeem);
+            defaultERC20PermitTransfer(address(ADDY), currentNonce, amountToRedeem);
         bytes memory signature = getSignature(
             permit, ownerPrivateKey, domainSeparator, TOKEN_PERMISSIONS_TYPEHASH, address(gasworks)
         );
@@ -124,8 +125,9 @@ contract GaslessTest is Test, Permit2Utils, ChamberTestUtils, DeployPermit2 {
             _minOutputReceive,
             amountToRedeem
         );
+        uint256 currentNonce = ERC20(address(USDC)).nonces(owner);
         ISignatureTransfer.PermitTransferFrom memory permit =
-            defaultERC20PermitTransfer(address(ADDY), nonce, amountToRedeem);
+            defaultERC20PermitTransfer(address(ADDY), currentNonce, amountToRedeem);
         bytes memory signature = getSignature(
             permit, ownerPrivateKey, domainSeparator, TOKEN_PERMISSIONS_TYPEHASH, address(gasworks)
         );
@@ -155,8 +157,9 @@ contract GaslessTest is Test, Permit2Utils, ChamberTestUtils, DeployPermit2 {
             _minOutputReceive,
             amountToRedeem
         );
+        uint256 currentNonce = ERC20(address(USDC)).nonces(owner);
         ISignatureTransfer.PermitTransferFrom memory permit =
-            defaultERC20PermitTransfer(address(ADDY), nonce, amountToRedeem);
+            defaultERC20PermitTransfer(address(ADDY), currentNonce, amountToRedeem);
         permit.deadline = 2 ** 255 - 1;
         bytes memory signature = getSignature(
             permit, ownerPrivateKey, domainSeparator, TOKEN_PERMISSIONS_TYPEHASH, address(gasworks)
@@ -185,8 +188,9 @@ contract GaslessTest is Test, Permit2Utils, ChamberTestUtils, DeployPermit2 {
             _minOutputReceive,
             amountToRedeem
         );
+        uint256 currentNonce = ERC20(address(USDC)).nonces(owner);
         ISignatureTransfer.PermitTransferFrom memory permit =
-            defaultERC20PermitTransfer(address(ADDY), nonce, amountToRedeem);
+            defaultERC20PermitTransfer(address(ADDY), currentNonce, amountToRedeem);
         bytes memory signature = getSignature(
             permit, ownerPrivateKey, domainSeparator, TOKEN_PERMISSIONS_TYPEHASH, address(gasworks)
         );
@@ -220,8 +224,9 @@ contract GaslessTest is Test, Permit2Utils, ChamberTestUtils, DeployPermit2 {
             _minOutputReceive,
             amountToRedeem
         );
+        uint256 currentNonce = ERC20(address(USDC)).nonces(owner);
         ISignatureTransfer.PermitTransferFrom memory permit =
-            defaultERC20PermitTransfer(address(ADDY), nonce, amountToRedeem);
+            defaultERC20PermitTransfer(address(ADDY), currentNonce, amountToRedeem);
         bytes memory signature = getSignature(
             permit, ownerPrivateKey, domainSeparator, TOKEN_PERMISSIONS_TYPEHASH, address(gasworks)
         );
@@ -255,8 +260,9 @@ contract GaslessTest is Test, Permit2Utils, ChamberTestUtils, DeployPermit2 {
             _minOutputReceive,
             amountToRedeem
         );
+        uint256 currentNonce = ERC20(address(USDC)).nonces(owner);
         ISignatureTransfer.PermitTransferFrom memory permit =
-            defaultERC20PermitTransfer(address(ADDY), nonce, amountToRedeem);
+            defaultERC20PermitTransfer(address(ADDY), currentNonce, amountToRedeem);
         bytes memory signature = getSignature(
             permit, ownerPrivateKey, domainSeparator, TOKEN_PERMISSIONS_TYPEHASH, address(gasworks)
         );
@@ -291,8 +297,9 @@ contract GaslessTest is Test, Permit2Utils, ChamberTestUtils, DeployPermit2 {
             amountToRedeem
         );
 
+        uint256 currentNonce = ERC20(address(USDC)).nonces(owner);
         ISignatureTransfer.PermitTransferFrom memory permit =
-            defaultERC20PermitTransfer(address(ADDY), nonce, amountToRedeem);
+            defaultERC20PermitTransfer(address(ADDY), currentNonce, amountToRedeem);
         bytes memory signature = getSignature(
             permit, ownerPrivateKey, domainSeparator, TOKEN_PERMISSIONS_TYPEHASH, address(gasworks)
         );
@@ -327,8 +334,9 @@ contract GaslessTest is Test, Permit2Utils, ChamberTestUtils, DeployPermit2 {
             amountToRedeem
         );
 
+        uint256 currentNonce = ERC20(address(USDC)).nonces(owner);
         ISignatureTransfer.PermitTransferFrom memory permit =
-            defaultERC20PermitTransfer(address(ADDY), nonce, amountToRedeem);
+            defaultERC20PermitTransfer(address(ADDY), currentNonce, amountToRedeem);
         bytes memory signature = getSignature(
             permit, ownerPrivateKey, domainSeparator, TOKEN_PERMISSIONS_TYPEHASH, address(gasworks)
         );

--- a/test/permit2/swapWithPermit2.t.sol
+++ b/test/permit2/swapWithPermit2.t.sol
@@ -197,7 +197,6 @@ contract GaslessTest is Test, Permit2Utils, DeployPermit2 {
         // bytes32 constant TOKEN_PERMISSIONS_TYPEHASH = keccak256("TokenPermissions(address token,uint256 amount)");
 
         uint256 currentNonce = USDC.nonces(owner);
-        // string memory nonce = USDC.name;
 
         ISignatureTransfer.PermitTransferFrom memory permit =
         ISignatureTransfer.PermitTransferFrom({

--- a/test/permit2/swapWithPermit2.t.sol
+++ b/test/permit2/swapWithPermit2.t.sol
@@ -186,7 +186,6 @@ contract GaslessTest is Test, Permit2Utils, DeployPermit2 {
      */
     function testSwapWithPermit2() public {
         uint256 currentNonce = USDC.nonces(owner);
-        // string memory nonce = USDC.name;
 
         ISignatureTransfer.PermitTransferFrom memory permit =
             defaultERC20PermitTransfer(address(USDC), currentNonce, 1e6);

--- a/test/permit2/swapWithPermit2.t.sol
+++ b/test/permit2/swapWithPermit2.t.sol
@@ -55,9 +55,8 @@ contract GaslessTest is Test, Permit2Utils, DeployPermit2 {
 
         ownerPrivateKey = 0xA11CE;
         owner = vm.addr(ownerPrivateKey);
-
-        vm.prank(0xe7804c37c13166fF0b37F5aE0BB07A3aEbb6e245);
-        USDC.safeTransfer(owner, 1e6);
+        
+        deal(address(USDC), owner, 1e6);
 
         vm.prank(owner);
         USDC.approve(permit2, 1e6);
@@ -186,8 +185,11 @@ contract GaslessTest is Test, Permit2Utils, DeployPermit2 {
      * [SUCCESS] Should make a success swap with permit2
      */
     function testSwapWithPermit2() public {
+        uint256 currentNonce = USDC.nonces(owner);
+        // string memory nonce = USDC.name;
+
         ISignatureTransfer.PermitTransferFrom memory permit =
-            defaultERC20PermitTransfer(address(USDC), 0, 1e6);
+            defaultERC20PermitTransfer(address(USDC), currentNonce, 1e6);
         bytes memory signature = getSignature(
             permit, ownerPrivateKey, domainSeparator, TOKEN_PERMISSIONS_TYPEHASH, address(gasworks)
         );

--- a/test/permit2/swapWithPermit2.t.sol
+++ b/test/permit2/swapWithPermit2.t.sol
@@ -37,12 +37,6 @@ contract GaslessTest is Test, Permit2Utils, DeployPermit2 {
     bytes32 internal domainSeparator;
     address internal permit2;
 
-    bytes internal constant PERMIT_WITNESS_TRANSFER_FROM_TYPE = "PermitWitnessTransferFrom(TokenPermissions permitted,address spender,uint256 nonce,uint256 deadline,";
-    bytes internal constant SWAP_DATA_TYPE = "SwapData(address buyToken,address spender,address swapTarget,bytes swapCallData,uint256 swapValue,uint256 buyAmount)";
-    bytes internal constant TOKEN_PERMISSIONS_TYPE = "TokenPermissions(address token,uint256 amount)";
-    bytes internal constant PERMIT2_SWAP_DATA_TYPE = abi.encodePacked("SwapData witness)", SWAP_DATA_TYPE, TOKEN_PERMISSIONS_TYPE);
-
-
     /*//////////////////////////////////////////////////////////////
                               SET UP
     //////////////////////////////////////////////////////////////*/
@@ -191,63 +185,13 @@ contract GaslessTest is Test, Permit2Utils, DeployPermit2 {
      * [SUCCESS] Should make a success swap with permit2
      */
     function testSwapWithPermit2() public {
-        
-        // bytes32 constant NAME_HASH = keccak256("Permit2");
-        // bytes32 constant TYPE_HASH = keccak256("EIP712Domain(string name,uint256 chainId,address verifyingContract)");
-        // bytes32 constant TOKEN_PERMISSIONS_TYPEHASH = keccak256("TokenPermissions(address token,uint256 amount)");
-
         uint256 currentNonce = USDC.nonces(owner);
 
         ISignatureTransfer.PermitTransferFrom memory permit =
-        ISignatureTransfer.PermitTransferFrom({
-            permitted: ISignatureTransfer.TokenPermissions({token: address(USDC), amount: 1e6}),
-            nonce: currentNonce,
-            deadline: block.timestamp + 100
-        });
-
-        // bytes memory concatenatedHashedQuotes;
-        // for (uint256 i = 0; i < swap.swapCallData.length;) {
-        //   concatenatedHashedQuotes = bytes.concat(concatenatedHashedQuotes, keccak256(swap.swapCallData[i]));
-        //   unchecked {
-        //     ++i;
-        //   }
-        // }
-
-        bytes32 witness = keccak256(abi.encode(
-          keccak256(abi.encodePacked(SWAP_DATA_TYPE)),
-          swapData.buyToken,
-          swapData.spender,
-          swapData.swapTarget,
-          keccak256(swapData.swapCallData),
-          swapData.swapValue,
-          swapData.buyAmount
-        ));
-        // bytes32 domainSeparator = keccak256(abi.encode(TYPE_HASH, NAME_HASH, block.chainid, address(USDC)));
-        bytes32 tokenPermissions = keccak256(abi.encode(TOKEN_PERMISSIONS_TYPEHASH, permit.permitted));
-        bytes32 msgHash = keccak256(abi.encodePacked(
-            "\x19\x01",
-            domainSeparator,
-            keccak256(
-                abi.encode(
-                    keccak256(abi.encodePacked(PERMIT_WITNESS_TRANSFER_FROM_TYPE, PERMIT2_SWAP_DATA_TYPE)),
-                    tokenPermissions,
-                    address(gasworks),
-                    permit.nonce,
-                    permit.deadline,
-                    witness
-                )
-            )
-        ));
-
-        (uint8 v, bytes32 r, bytes32 s) = vm.sign(ownerPrivateKey, msgHash);
-        bytes memory signature = bytes.concat(r, s, bytes1(v));
-
-        
-
-        
-        // bytes memory signature = getSignature(
-        //     permit, ownerPrivateKey, domainSeparator, TOKEN_PERMISSIONS_TYPEHASH, address(gasworks)
-        // );
+            defaultERC20PermitTransfer(address(USDC), currentNonce, 1e6);
+        bytes memory signature = getSignature(
+            permit, ownerPrivateKey, domainSeparator, TOKEN_PERMISSIONS_TYPEHASH, address(gasworks)
+        );
 
         gasworks.swapWithPermit2(permit, owner, signature, swapData);
 
@@ -260,7 +204,7 @@ contract GaslessTest is Test, Permit2Utils, DeployPermit2 {
     /**
      * [SUCCESS] Should make a success swap to native MATIC with permit2
      */
-    function testSwapWToNativeMATICithPermit2() public {
+    function testSwapWithPermit2ToNativeMATIC() public {
         string[] memory inputs = new string[](4);
         inputs[0] = "node";
         inputs[1] = "scripts/fetch-quote.js";

--- a/test/permit2/swapWithPermit2.t.sol
+++ b/test/permit2/swapWithPermit2.t.sol
@@ -186,6 +186,7 @@ contract GaslessTest is Test, Permit2Utils, DeployPermit2 {
      */
     function testSwapWithPermit2() public {
         uint256 currentNonce = USDC.nonces(owner);
+        // string memory nonce = USDC.name;
 
         ISignatureTransfer.PermitTransferFrom memory permit =
             defaultERC20PermitTransfer(address(USDC), currentNonce, 1e6);

--- a/test/permit2/swapWithPermit2.t.sol
+++ b/test/permit2/swapWithPermit2.t.sol
@@ -37,6 +37,12 @@ contract GaslessTest is Test, Permit2Utils, DeployPermit2 {
     bytes32 internal domainSeparator;
     address internal permit2;
 
+    bytes internal constant PERMIT_WITNESS_TRANSFER_FROM_TYPE = "PermitWitnessTransferFrom(TokenPermissions permitted,address spender,uint256 nonce,uint256 deadline,";
+    bytes internal constant SWAP_DATA_TYPE = "SwapData(address buyToken,address spender,address swapTarget,bytes swapCallData,uint256 swapValue,uint256 buyAmount)";
+    bytes internal constant TOKEN_PERMISSIONS_TYPE = "TokenPermissions(address token,uint256 amount)";
+    bytes internal constant PERMIT2_SWAP_DATA_TYPE = abi.encodePacked("SwapData witness)", SWAP_DATA_TYPE, TOKEN_PERMISSIONS_TYPE);
+
+
     /*//////////////////////////////////////////////////////////////
                               SET UP
     //////////////////////////////////////////////////////////////*/
@@ -185,13 +191,63 @@ contract GaslessTest is Test, Permit2Utils, DeployPermit2 {
      * [SUCCESS] Should make a success swap with permit2
      */
     function testSwapWithPermit2() public {
+        
+        // bytes32 constant NAME_HASH = keccak256("Permit2");
+        // bytes32 constant TYPE_HASH = keccak256("EIP712Domain(string name,uint256 chainId,address verifyingContract)");
+        // bytes32 constant TOKEN_PERMISSIONS_TYPEHASH = keccak256("TokenPermissions(address token,uint256 amount)");
+
         uint256 currentNonce = USDC.nonces(owner);
 
         ISignatureTransfer.PermitTransferFrom memory permit =
-            defaultERC20PermitTransfer(address(USDC), currentNonce, 1e6);
-        bytes memory signature = getSignature(
-            permit, ownerPrivateKey, domainSeparator, TOKEN_PERMISSIONS_TYPEHASH, address(gasworks)
-        );
+        ISignatureTransfer.PermitTransferFrom({
+            permitted: ISignatureTransfer.TokenPermissions({token: address(USDC), amount: 1e6}),
+            nonce: currentNonce,
+            deadline: block.timestamp + 100
+        });
+
+        // bytes memory concatenatedHashedQuotes;
+        // for (uint256 i = 0; i < swap.swapCallData.length;) {
+        //   concatenatedHashedQuotes = bytes.concat(concatenatedHashedQuotes, keccak256(swap.swapCallData[i]));
+        //   unchecked {
+        //     ++i;
+        //   }
+        // }
+
+        bytes32 witness = keccak256(abi.encode(
+          keccak256(abi.encodePacked(SWAP_DATA_TYPE)),
+          swapData.buyToken,
+          swapData.spender,
+          swapData.swapTarget,
+          keccak256(swapData.swapCallData),
+          swapData.swapValue,
+          swapData.buyAmount
+        ));
+        // bytes32 domainSeparator = keccak256(abi.encode(TYPE_HASH, NAME_HASH, block.chainid, address(USDC)));
+        bytes32 tokenPermissions = keccak256(abi.encode(TOKEN_PERMISSIONS_TYPEHASH, permit.permitted));
+        bytes32 msgHash = keccak256(abi.encodePacked(
+            "\x19\x01",
+            domainSeparator,
+            keccak256(
+                abi.encode(
+                    keccak256(abi.encodePacked(PERMIT_WITNESS_TRANSFER_FROM_TYPE, PERMIT2_SWAP_DATA_TYPE)),
+                    tokenPermissions,
+                    address(gasworks),
+                    permit.nonce,
+                    permit.deadline,
+                    witness
+                )
+            )
+        ));
+
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(ownerPrivateKey, msgHash);
+        bytes memory signature = bytes.concat(r, s, bytes1(v));
+
+        
+
+        
+        // bytes memory signature = getSignature(
+        //     permit, ownerPrivateKey, domainSeparator, TOKEN_PERMISSIONS_TYPEHASH, address(gasworks)
+        // );
 
         gasworks.swapWithPermit2(permit, owner, signature, swapData);
 
@@ -204,7 +260,7 @@ contract GaslessTest is Test, Permit2Utils, DeployPermit2 {
     /**
      * [SUCCESS] Should make a success swap to native MATIC with permit2
      */
-    function testSwapWithPermit2ToNativeMATIC() public {
+    function testSwapWToNativeMATICithPermit2() public {
         string[] memory inputs = new string[](4);
         inputs[0] = "node";
         inputs[1] = "scripts/fetch-quote.js";


### PR DESCRIPTION
The `swapData` that is passed though params in the function `swapWithPermit2` is hashed on-chain, and then verified though `permitWitnessTransferFrom`. This allows to call the gasworks ONLY with the permit2 the user signed, that includes the hash of the swapData in the witness field

TODO: Fix other tests, improve constants order in the code.

TODO: Test

- Try calling `swapData` with different params that the ones signed in permit2
- Try calling `swapData` with the same permit2 twice