### PR TITLE
:sparkles: Mint chambers with permit2 and witness

### DIFF
--- a/scripts/fetch-arch-quote.js
+++ b/scripts/fetch-arch-quote.js
@@ -14,7 +14,7 @@ async function generateJwt(payload) {
   return jwt;
 }
 
-const issuance = '0x0000000000000000000000000000000000000000000000000000000000000000';
+const issuance = '0x0000000000000000000000000000000000000000000000000000000000000001';
 
 async function main(quantity, basketAddress, tokenAddress, operation) {
   const qty = encoder.decode(["uint256"], quantity)[0]

--- a/src/interfaces/IGasworks.sol
+++ b/src/interfaces/IGasworks.sol
@@ -37,6 +37,7 @@ import { IERC20 } from "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol"
 import { ITradeIssuerV2 } from "chambers-peripherals/src/interfaces/ITradeIssuerV2.sol";
 import { IChamber } from "chambers/interfaces/IChamber.sol";
 import { IIssuerWizard } from "chambers/interfaces/IIssuerWizard.sol";
+import { ITradeIssuerV2 } from "chambers-peripherals/src/interfaces/ITradeIssuerV2.sol";
 
 interface IGasworks {
     /*//////////////////////////////////////////////////////////////
@@ -92,17 +93,29 @@ interface IGasworks {
         bool _isDebtIssuance;
     }
 
+    struct ContractCallInstruction {
+        address contractTarget;
+        address allowanceTarget;
+        address sellToken;
+        uint256 sellAmount;
+        address buyToken;
+        uint256 minBuyAmount;
+        bytes callData;
+    }
+
     struct MintChamberData {
         // The address of the chamber to mint
-        IChamber _chamber;
-        // The address of the issuer wizard that will mint the Chamber
-        IIssuerWizard _issuerWizard;
-        // The address of the token used to mint
-        IERC20 _baseToken;
-        // Maximum amount of baseToken to use to mint
-        uint256 _maxPayAmount;
+        address chamber;
         // The amount of Chamber to mint
-        uint256 _mintAmount;
+        uint256 chamberAmount;
+        // The address of the token used to mint
+        address inputToken;
+        // Maximum amount of baseToken to use to mint
+        uint256 inputTokenMaxAmount;
+        // The address of the issuer wizard that will mint the Chamber
+        address issuerWizard;
+        // Intructions to pass the TradeIssuer
+        ContractCallInstruction[] tradeIssuerCallInstructions;
     }
 
     struct RedeemChamberData {
@@ -166,11 +179,11 @@ interface IGasworks {
 
     function mintWithPermit(PermitData calldata permit, MintSetData calldata mintData) external;
 
-    function mintChamberWithPermit(
-        PermitData calldata permit,
-        MintChamberData calldata mintChamberData,
-        ITradeIssuerV2.ContractCallInstruction[] memory contractCallInstructions
-    ) external;
+    // function mintChamberWithPermit(
+    //     PermitData calldata permit,
+    //     MintChamberData calldata mintChamberData,
+    //     ITradeIssuerV2.ContractCallInstruction[] memory contractCallInstructions
+    // ) external;
 
     function swapWithPermit2(
         ISignatureTransfer.PermitTransferFrom memory permit2,
@@ -183,8 +196,7 @@ interface IGasworks {
         ISignatureTransfer.PermitTransferFrom memory permit2,
         address owner,
         bytes calldata signature,
-        MintChamberData calldata mintChamberData,
-        ITradeIssuerV2.ContractCallInstruction[] memory contractCallInstructions
+        MintChamberData calldata mintChamberData
     ) external;
 
     function redeemChamberWithPermit2(

--- a/test/permit/mintChamberWithPermit.t.sol
+++ b/test/permit/mintChamberWithPermit.t.sol
@@ -1,457 +1,457 @@
-// SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.17.0;
+// // SPDX-License-Identifier: UNLICENSED
+// pragma solidity ^0.8.17.0;
 
-import { Test } from "forge-std/Test.sol";
-import { Gasworks } from "src/Gasworks.sol";
-import { IGasworks } from "src/interfaces/IGasworks.sol";
-import { IERC20 } from "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
-import { SafeERC20 } from "openzeppelin-contracts/contracts/token/ERC20/utils/SafeERC20.sol";
-import { Conversor } from "test/utils/HexUtils.sol";
-import { ChamberTestUtils } from "chambers-peripherals/test/utils/ChamberTestUtils.sol";
-import { ITradeIssuerV2 } from "chambers-peripherals/src/interfaces/ITradeIssuerV2.sol";
-import { IChamber } from "chambers/interfaces/IChamber.sol";
-import { IIssuerWizard } from "chambers/interfaces/IIssuerWizard.sol";
-import { SigUtils } from "test/utils/SigUtils.sol";
-import { IERC20Permit } from
-    "openzeppelin-contracts/contracts/token/ERC20/extensions/IERC20Permit.sol";
+// import { Test } from "forge-std/Test.sol";
+// import { Gasworks } from "src/Gasworks.sol";
+// import { IGasworks } from "src/interfaces/IGasworks.sol";
+// import { IERC20 } from "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
+// import { SafeERC20 } from "openzeppelin-contracts/contracts/token/ERC20/utils/SafeERC20.sol";
+// import { Conversor } from "test/utils/HexUtils.sol";
+// import { ChamberTestUtils } from "chambers-peripherals/test/utils/ChamberTestUtils.sol";
+// import { ITradeIssuerV2 } from "chambers-peripherals/src/interfaces/ITradeIssuerV2.sol";
+// import { IChamber } from "chambers/interfaces/IChamber.sol";
+// import { IIssuerWizard } from "chambers/interfaces/IIssuerWizard.sol";
+// import { SigUtils } from "test/utils/SigUtils.sol";
+// import { IERC20Permit } from
+//     "openzeppelin-contracts/contracts/token/ERC20/extensions/IERC20Permit.sol";
 
-contract GaslessTest is Test, ChamberTestUtils {
-    /*//////////////////////////////////////////////////////////////
-                              VARIABLES
-    //////////////////////////////////////////////////////////////*/
-    using SafeERC20 for IERC20;
+// contract GaslessTest is Test, ChamberTestUtils {
+//     /*//////////////////////////////////////////////////////////////
+//                               VARIABLES
+//     //////////////////////////////////////////////////////////////*/
+//     using SafeERC20 for IERC20;
 
-    IERC20 internal constant USDC = IERC20(0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174);
-    IChamber internal constant AAGG = IChamber(0xAfb6E8331355faE99C8E8953bB4c6Dc5d11E9F3c);
+//     IERC20 internal constant USDC = IERC20(0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174);
+//     IChamber internal constant AAGG = IChamber(0xAfb6E8331355faE99C8E8953bB4c6Dc5d11E9F3c);
 
-    Gasworks internal gasworks;
-    SigUtils internal sigUtils;
-    uint256 internal ownerPrivateKey;
-    address internal owner;
+//     Gasworks internal gasworks;
+//     SigUtils internal sigUtils;
+//     uint256 internal ownerPrivateKey;
+//     address internal owner;
 
-    IGasworks.MintChamberData internal mintData;
-    bytes internal res;
-    uint256 internal amountToMint = 10e18;
-    uint256 internal nonce;
+//     IGasworks.MintChamberData internal mintData;
+//     bytes internal res;
+//     uint256 internal amountToMint = 10e18;
+//     uint256 internal nonce;
 
-    /*//////////////////////////////////////////////////////////////
-                              SET UP
-    //////////////////////////////////////////////////////////////*/
-    function setUp() public {
-        gasworks = new Gasworks(
-            0xdA78a11FD57aF7be2eDD804840eA7f4c2A38801d,
-            0x1c0c05a2aA31692e5dc9511b04F651db9E4d8320,
-            0x2B13D2b9407D5776B0BB63c8cd144978B6B7cE58
-        );
-        gasworks.setTokens(address(USDC));
-        gasworks.setTokens(address(AAGG));
+//     /*//////////////////////////////////////////////////////////////
+//                               SET UP
+//     //////////////////////////////////////////////////////////////*/
+//     function setUp() public {
+//         gasworks = new Gasworks(
+//             0xdA78a11FD57aF7be2eDD804840eA7f4c2A38801d,
+//             0x1c0c05a2aA31692e5dc9511b04F651db9E4d8320,
+//             0x2B13D2b9407D5776B0BB63c8cd144978B6B7cE58
+//         );
+//         gasworks.setTokens(address(USDC));
+//         gasworks.setTokens(address(AAGG));
 
-        vm.label(0x2B13D2b9407D5776B0BB63c8cd144978B6B7cE58, "TradeIssuerV2");
+//         vm.label(0x2B13D2b9407D5776B0BB63c8cd144978B6B7cE58, "TradeIssuerV2");
 
-        sigUtils = new SigUtils(IERC20Permit(address(USDC)).DOMAIN_SEPARATOR());
+//         sigUtils = new SigUtils(IERC20Permit(address(USDC)).DOMAIN_SEPARATOR());
 
-        ownerPrivateKey = 0xA11CE;
-        owner = vm.addr(ownerPrivateKey);
+//         ownerPrivateKey = 0xA11CE;
+//         owner = vm.addr(ownerPrivateKey);
 
-        string[] memory inputs = new string[](6);
-        inputs[0] = "node";
-        inputs[1] = "scripts/fetch-arch-quote.js";
-        inputs[2] = Conversor.iToHex(abi.encode(amountToMint));
-        inputs[3] = Conversor.iToHex(abi.encode(address(AAGG)));
-        inputs[4] = Conversor.iToHex(abi.encode(address(USDC)));
-        inputs[5] = Conversor.iToHex(abi.encode(true));
-        res = vm.ffi(inputs);
+//         string[] memory inputs = new string[](6);
+//         inputs[0] = "node";
+//         inputs[1] = "scripts/fetch-arch-quote.js";
+//         inputs[2] = Conversor.iToHex(abi.encode(amountToMint));
+//         inputs[3] = Conversor.iToHex(abi.encode(address(AAGG)));
+//         inputs[4] = Conversor.iToHex(abi.encode(address(USDC)));
+//         inputs[5] = Conversor.iToHex(abi.encode(true));
+//         res = vm.ffi(inputs);
 
-        vm.prank(0xe7804c37c13166fF0b37F5aE0BB07A3aEbb6e245);
-        USDC.safeTransfer(owner, 150e6);
+//         vm.prank(0xe7804c37c13166fF0b37F5aE0BB07A3aEbb6e245);
+//         USDC.safeTransfer(owner, 150e6);
 
-        nonce = IERC20Permit(address(USDC)).nonces(owner);
-    }
+//         nonce = IERC20Permit(address(USDC)).nonces(owner);
+//     }
 
-    /*//////////////////////////////////////////////////////////////
-                              REVERT
-    //////////////////////////////////////////////////////////////*/
+//     /*//////////////////////////////////////////////////////////////
+//                               REVERT
+//     //////////////////////////////////////////////////////////////*/
 
-    /**
-     * [REVERT] Should revert because the permit is expired
-     */
-    function testCannotMintWithExpiredPermit() public {
-        (
-            ITradeIssuerV2.ContractCallInstruction[] memory _contractCallInstructions,
-            uint256 _maxPayAmount
-        ) = abi.decode(res, (ITradeIssuerV2.ContractCallInstruction[], uint256));
-        mintData = IGasworks.MintChamberData(
-            AAGG,
-            IIssuerWizard(0x60F56236CD3C1Ac146BD94F2006a1335BaA4c449),
-            USDC,
-            _maxPayAmount,
-            amountToMint
-        );
+//     /**
+//      * [REVERT] Should revert because the permit is expired
+//      */
+//     function testCannotMintWithExpiredPermit() public {
+//         (
+//             ITradeIssuerV2.ContractCallInstruction[] memory _contractCallInstructions,
+//             uint256 _maxPayAmount
+//         ) = abi.decode(res, (ITradeIssuerV2.ContractCallInstruction[], uint256));
+//         mintData = IGasworks.MintChamberData(
+//             AAGG,
+//             IIssuerWizard(0x60F56236CD3C1Ac146BD94F2006a1335BaA4c449),
+//             USDC,
+//             _maxPayAmount,
+//             amountToMint
+//         );
 
-        SigUtils.Permit memory permit = SigUtils.Permit({
-            owner: owner,
-            spender: address(gasworks),
-            value: 1e18,
-            nonce: nonce,
-            deadline: 2 ** 255 - 1
-        });
+//         SigUtils.Permit memory permit = SigUtils.Permit({
+//             owner: owner,
+//             spender: address(gasworks),
+//             value: 1e18,
+//             nonce: nonce,
+//             deadline: 2 ** 255 - 1
+//         });
 
-        bytes32 digest = sigUtils.getTypedDataHash(permit);
+//         bytes32 digest = sigUtils.getTypedDataHash(permit);
 
-        (uint8 v, bytes32 r, bytes32 s) = vm.sign(ownerPrivateKey, digest);
+//         (uint8 v, bytes32 r, bytes32 s) = vm.sign(ownerPrivateKey, digest);
 
-        vm.warp(2 ** 255 + 1); // fast forwards one second past the deadline
+//         vm.warp(2 ** 255 + 1); // fast forwards one second past the deadline
 
-        vm.expectRevert("Permit: permit is expired");
-        gasworks.mintChamberWithPermit(
-            IGasworks.PermitData(
-                address(USDC),
-                1e18,
-                permit.owner,
-                permit.spender,
-                permit.value,
-                permit.deadline,
-                v,
-                r,
-                s
-            ),
-            mintData,
-            _contractCallInstructions
-        );
-    }
+//         vm.expectRevert("Permit: permit is expired");
+//         gasworks.mintChamberWithPermit(
+//             IGasworks.PermitData(
+//                 address(USDC),
+//                 1e18,
+//                 permit.owner,
+//                 permit.spender,
+//                 permit.value,
+//                 permit.deadline,
+//                 v,
+//                 r,
+//                 s
+//             ),
+//             mintData,
+//             _contractCallInstructions
+//         );
+//     }
 
-    /**
-     * [REVERT] Should revert because the signer of the permit
-     * is not the owner of the tokens
-     */
-    function testCannotMintWithInvalidSigner() public {
-        (
-            ITradeIssuerV2.ContractCallInstruction[] memory _contractCallInstructions,
-            uint256 _maxPayAmount
-        ) = abi.decode(res, (ITradeIssuerV2.ContractCallInstruction[], uint256));
-        mintData = IGasworks.MintChamberData(
-            AAGG,
-            IIssuerWizard(0x60F56236CD3C1Ac146BD94F2006a1335BaA4c449),
-            USDC,
-            _maxPayAmount,
-            amountToMint
-        );
+//     /**
+//      * [REVERT] Should revert because the signer of the permit
+//      * is not the owner of the tokens
+//      */
+//     function testCannotMintWithInvalidSigner() public {
+//         (
+//             ITradeIssuerV2.ContractCallInstruction[] memory _contractCallInstructions,
+//             uint256 _maxPayAmount
+//         ) = abi.decode(res, (ITradeIssuerV2.ContractCallInstruction[], uint256));
+//         mintData = IGasworks.MintChamberData(
+//             AAGG,
+//             IIssuerWizard(0x60F56236CD3C1Ac146BD94F2006a1335BaA4c449),
+//             USDC,
+//             _maxPayAmount,
+//             amountToMint
+//         );
 
-        SigUtils.Permit memory permit = SigUtils.Permit({
-            owner: owner,
-            spender: address(gasworks),
-            value: 1e18,
-            nonce: nonce,
-            deadline: 2 ** 256 - 1
-        });
+//         SigUtils.Permit memory permit = SigUtils.Permit({
+//             owner: owner,
+//             spender: address(gasworks),
+//             value: 1e18,
+//             nonce: nonce,
+//             deadline: 2 ** 256 - 1
+//         });
 
-        bytes32 digest = sigUtils.getTypedDataHash(permit);
+//         bytes32 digest = sigUtils.getTypedDataHash(permit);
 
-        (uint8 v, bytes32 r, bytes32 s) = vm.sign(0xB0B, digest); // 0xB0B signs but 0xA11CE is owner
+//         (uint8 v, bytes32 r, bytes32 s) = vm.sign(0xB0B, digest); // 0xB0B signs but 0xA11CE is owner
 
-        vm.expectRevert("Permit: invalid signature");
-        gasworks.mintChamberWithPermit(
-            IGasworks.PermitData(
-                address(USDC),
-                1e18,
-                permit.owner,
-                permit.spender,
-                permit.value,
-                permit.deadline,
-                v,
-                r,
-                s
-            ),
-            mintData,
-            _contractCallInstructions
-        );
-    }
+//         vm.expectRevert("Permit: invalid signature");
+//         gasworks.mintChamberWithPermit(
+//             IGasworks.PermitData(
+//                 address(USDC),
+//                 1e18,
+//                 permit.owner,
+//                 permit.spender,
+//                 permit.value,
+//                 permit.deadline,
+//                 v,
+//                 r,
+//                 s
+//             ),
+//             mintData,
+//             _contractCallInstructions
+//         );
+//     }
 
-    /**
-     * [REVERT] Should revert because the nonce is invalid
-     */
-    function testCannotMintWithInvalidNonce() public {
-        (
-            ITradeIssuerV2.ContractCallInstruction[] memory _contractCallInstructions,
-            uint256 _maxPayAmount
-        ) = abi.decode(res, (ITradeIssuerV2.ContractCallInstruction[], uint256));
-        mintData = IGasworks.MintChamberData(
-            AAGG,
-            IIssuerWizard(0x60F56236CD3C1Ac146BD94F2006a1335BaA4c449),
-            USDC,
-            _maxPayAmount,
-            amountToMint
-        );
+//     /**
+//      * [REVERT] Should revert because the nonce is invalid
+//      */
+//     function testCannotMintWithInvalidNonce() public {
+//         (
+//             ITradeIssuerV2.ContractCallInstruction[] memory _contractCallInstructions,
+//             uint256 _maxPayAmount
+//         ) = abi.decode(res, (ITradeIssuerV2.ContractCallInstruction[], uint256));
+//         mintData = IGasworks.MintChamberData(
+//             AAGG,
+//             IIssuerWizard(0x60F56236CD3C1Ac146BD94F2006a1335BaA4c449),
+//             USDC,
+//             _maxPayAmount,
+//             amountToMint
+//         );
 
-        SigUtils.Permit memory permit = SigUtils.Permit({
-            owner: owner,
-            spender: address(gasworks),
-            value: 1e18,
-            nonce: 1, // set nonce to 1 instead of 0
-            deadline: 2 ** 256 - 1
-        });
+//         SigUtils.Permit memory permit = SigUtils.Permit({
+//             owner: owner,
+//             spender: address(gasworks),
+//             value: 1e18,
+//             nonce: 1, // set nonce to 1 instead of 0
+//             deadline: 2 ** 256 - 1
+//         });
 
-        bytes32 digest = sigUtils.getTypedDataHash(permit);
+//         bytes32 digest = sigUtils.getTypedDataHash(permit);
 
-        (uint8 v, bytes32 r, bytes32 s) = vm.sign(ownerPrivateKey, digest);
+//         (uint8 v, bytes32 r, bytes32 s) = vm.sign(ownerPrivateKey, digest);
 
-        vm.expectRevert("Permit: invalid signature");
-        gasworks.mintChamberWithPermit(
-            IGasworks.PermitData(
-                address(USDC),
-                1e18,
-                permit.owner,
-                permit.spender,
-                permit.value,
-                permit.deadline,
-                v,
-                r,
-                s
-            ),
-            mintData,
-            _contractCallInstructions
-        );
-    }
+//         vm.expectRevert("Permit: invalid signature");
+//         gasworks.mintChamberWithPermit(
+//             IGasworks.PermitData(
+//                 address(USDC),
+//                 1e18,
+//                 permit.owner,
+//                 permit.spender,
+//                 permit.value,
+//                 permit.deadline,
+//                 v,
+//                 r,
+//                 s
+//             ),
+//             mintData,
+//             _contractCallInstructions
+//         );
+//     }
 
-    /**
-     * [REVERT] Should revert because allowed amount is less than required amount
-     */
-    function testCannotMintWithInvalidAllowance() public {
-        (
-            ITradeIssuerV2.ContractCallInstruction[] memory _contractCallInstructions,
-            uint256 _maxPayAmount
-        ) = abi.decode(res, (ITradeIssuerV2.ContractCallInstruction[], uint256));
-        mintData = IGasworks.MintChamberData(
-            AAGG,
-            IIssuerWizard(0x60F56236CD3C1Ac146BD94F2006a1335BaA4c449),
-            USDC,
-            _maxPayAmount,
-            amountToMint
-        );
+//     /**
+//      * [REVERT] Should revert because allowed amount is less than required amount
+//      */
+//     function testCannotMintWithInvalidAllowance() public {
+//         (
+//             ITradeIssuerV2.ContractCallInstruction[] memory _contractCallInstructions,
+//             uint256 _maxPayAmount
+//         ) = abi.decode(res, (ITradeIssuerV2.ContractCallInstruction[], uint256));
+//         mintData = IGasworks.MintChamberData(
+//             AAGG,
+//             IIssuerWizard(0x60F56236CD3C1Ac146BD94F2006a1335BaA4c449),
+//             USDC,
+//             _maxPayAmount,
+//             amountToMint
+//         );
 
-        SigUtils.Permit memory permit = SigUtils.Permit({
-            owner: owner,
-            spender: address(gasworks),
-            value: 5e5,
-            nonce: 0,
-            deadline: 2 ** 256 - 1
-        });
+//         SigUtils.Permit memory permit = SigUtils.Permit({
+//             owner: owner,
+//             spender: address(gasworks),
+//             value: 5e5,
+//             nonce: 0,
+//             deadline: 2 ** 256 - 1
+//         });
 
-        bytes32 digest = sigUtils.getTypedDataHash(permit);
+//         bytes32 digest = sigUtils.getTypedDataHash(permit);
 
-        (uint8 v, bytes32 r, bytes32 s) = vm.sign(ownerPrivateKey, digest);
+//         (uint8 v, bytes32 r, bytes32 s) = vm.sign(ownerPrivateKey, digest);
 
-        vm.expectRevert("TRANSFER_FROM_FAILED");
-        gasworks.mintChamberWithPermit(
-            IGasworks.PermitData(
-                address(USDC),
-                1e18,
-                permit.owner,
-                permit.spender,
-                permit.value,
-                permit.deadline,
-                v,
-                r,
-                s
-            ),
-            mintData,
-            _contractCallInstructions
-        );
-    }
+//         vm.expectRevert("TRANSFER_FROM_FAILED");
+//         gasworks.mintChamberWithPermit(
+//             IGasworks.PermitData(
+//                 address(USDC),
+//                 1e18,
+//                 permit.owner,
+//                 permit.spender,
+//                 permit.value,
+//                 permit.deadline,
+//                 v,
+//                 r,
+//                 s
+//             ),
+//             mintData,
+//             _contractCallInstructions
+//         );
+//     }
 
-    /**
-     * [REVERT] Should revert because balance is less than required amount
-     */
-    function testCannotMintWithInvalidBalance() public {
-        (
-            ITradeIssuerV2.ContractCallInstruction[] memory _contractCallInstructions,
-            uint256 _maxPayAmount
-        ) = abi.decode(res, (ITradeIssuerV2.ContractCallInstruction[], uint256));
-        mintData = IGasworks.MintChamberData(
-            AAGG,
-            IIssuerWizard(0x60F56236CD3C1Ac146BD94F2006a1335BaA4c449),
-            USDC,
-            _maxPayAmount,
-            amountToMint
-        );
+//     /**
+//      * [REVERT] Should revert because balance is less than required amount
+//      */
+//     function testCannotMintWithInvalidBalance() public {
+//         (
+//             ITradeIssuerV2.ContractCallInstruction[] memory _contractCallInstructions,
+//             uint256 _maxPayAmount
+//         ) = abi.decode(res, (ITradeIssuerV2.ContractCallInstruction[], uint256));
+//         mintData = IGasworks.MintChamberData(
+//             AAGG,
+//             IIssuerWizard(0x60F56236CD3C1Ac146BD94F2006a1335BaA4c449),
+//             USDC,
+//             _maxPayAmount,
+//             amountToMint
+//         );
 
-        SigUtils.Permit memory permit = SigUtils.Permit({
-            owner: owner,
-            spender: address(gasworks),
-            value: 2e18,
-            nonce: 0,
-            deadline: 2 ** 256 - 1
-        });
+//         SigUtils.Permit memory permit = SigUtils.Permit({
+//             owner: owner,
+//             spender: address(gasworks),
+//             value: 2e18,
+//             nonce: 0,
+//             deadline: 2 ** 256 - 1
+//         });
 
-        bytes32 digest = sigUtils.getTypedDataHash(permit);
+//         bytes32 digest = sigUtils.getTypedDataHash(permit);
 
-        (uint8 v, bytes32 r, bytes32 s) = vm.sign(ownerPrivateKey, digest);
+//         (uint8 v, bytes32 r, bytes32 s) = vm.sign(ownerPrivateKey, digest);
 
-        vm.expectRevert("TRANSFER_FROM_FAILED");
-        gasworks.mintChamberWithPermit(
-            IGasworks.PermitData(
-                address(USDC),
-                2e18, // owner was only minted 1 USDC
-                permit.owner,
-                permit.spender,
-                permit.value,
-                permit.deadline,
-                v,
-                r,
-                s
-            ),
-            mintData,
-            _contractCallInstructions
-        );
-    }
+//         vm.expectRevert("TRANSFER_FROM_FAILED");
+//         gasworks.mintChamberWithPermit(
+//             IGasworks.PermitData(
+//                 address(USDC),
+//                 2e18, // owner was only minted 1 USDC
+//                 permit.owner,
+//                 permit.spender,
+//                 permit.value,
+//                 permit.deadline,
+//                 v,
+//                 r,
+//                 s
+//             ),
+//             mintData,
+//             _contractCallInstructions
+//         );
+//     }
 
-    /**
-     * [REVERT] Should revert because mintData is invalid
-     */
-    function testCannotMintWithInvalidPayload() public {
-        (
-            ITradeIssuerV2.ContractCallInstruction[] memory _contractCallInstructions,
-            uint256 _maxPayAmount
-        ) = abi.decode(res, (ITradeIssuerV2.ContractCallInstruction[], uint256));
-        mintData = IGasworks.MintChamberData(
-            AAGG,
-            IIssuerWizard(0x60F56236CD3C1Ac146BD94F2006a1335BaA4c449),
-            USDC,
-            _maxPayAmount,
-            amountToMint
-        );
+//     /**
+//      * [REVERT] Should revert because mintData is invalid
+//      */
+//     function testCannotMintWithInvalidPayload() public {
+//         (
+//             ITradeIssuerV2.ContractCallInstruction[] memory _contractCallInstructions,
+//             uint256 _maxPayAmount
+//         ) = abi.decode(res, (ITradeIssuerV2.ContractCallInstruction[], uint256));
+//         mintData = IGasworks.MintChamberData(
+//             AAGG,
+//             IIssuerWizard(0x60F56236CD3C1Ac146BD94F2006a1335BaA4c449),
+//             USDC,
+//             _maxPayAmount,
+//             amountToMint
+//         );
 
-        _contractCallInstructions[0]._callData = bytes("bad data");
+//         _contractCallInstructions[0]._callData = bytes("bad data");
 
-        SigUtils.Permit memory permit = SigUtils.Permit({
-            owner: owner,
-            spender: address(gasworks),
-            value: mintData._maxPayAmount,
-            nonce: nonce,
-            deadline: 2 ** 256 - 1
-        });
+//         SigUtils.Permit memory permit = SigUtils.Permit({
+//             owner: owner,
+//             spender: address(gasworks),
+//             value: mintData._maxPayAmount,
+//             nonce: nonce,
+//             deadline: 2 ** 256 - 1
+//         });
 
-        bytes32 digest = sigUtils.getTypedDataHash(permit);
+//         bytes32 digest = sigUtils.getTypedDataHash(permit);
 
-        (uint8 v, bytes32 r, bytes32 s) = vm.sign(ownerPrivateKey, digest);
+//         (uint8 v, bytes32 r, bytes32 s) = vm.sign(ownerPrivateKey, digest);
 
-        vm.expectRevert();
-        gasworks.mintChamberWithPermit(
-            IGasworks.PermitData(
-                address(USDC),
-                mintData._maxPayAmount,
-                permit.owner,
-                permit.spender,
-                permit.value,
-                permit.deadline,
-                v,
-                r,
-                s
-            ),
-            mintData,
-            _contractCallInstructions
-        );
-    }
+//         vm.expectRevert();
+//         gasworks.mintChamberWithPermit(
+//             IGasworks.PermitData(
+//                 address(USDC),
+//                 mintData._maxPayAmount,
+//                 permit.owner,
+//                 permit.spender,
+//                 permit.value,
+//                 permit.deadline,
+//                 v,
+//                 r,
+//                 s
+//             ),
+//             mintData,
+//             _contractCallInstructions
+//         );
+//     }
 
-    /**
-     * [REVERT] Should revert because token is not permitted
-     */
-    function testCannotMintWithInvalidToken() public {
-        (
-            ITradeIssuerV2.ContractCallInstruction[] memory _contractCallInstructions,
-            uint256 _maxPayAmount
-        ) = abi.decode(res, (ITradeIssuerV2.ContractCallInstruction[], uint256));
-        mintData = IGasworks.MintChamberData(
-            AAGG,
-            IIssuerWizard(0x60F56236CD3C1Ac146BD94F2006a1335BaA4c449),
-            USDC,
-            _maxPayAmount,
-            amountToMint
-        );
+//     /**
+//      * [REVERT] Should revert because token is not permitted
+//      */
+//     function testCannotMintWithInvalidToken() public {
+//         (
+//             ITradeIssuerV2.ContractCallInstruction[] memory _contractCallInstructions,
+//             uint256 _maxPayAmount
+//         ) = abi.decode(res, (ITradeIssuerV2.ContractCallInstruction[], uint256));
+//         mintData = IGasworks.MintChamberData(
+//             AAGG,
+//             IIssuerWizard(0x60F56236CD3C1Ac146BD94F2006a1335BaA4c449),
+//             USDC,
+//             _maxPayAmount,
+//             amountToMint
+//         );
 
-        SigUtils.Permit memory permit = SigUtils.Permit({
-            owner: owner,
-            spender: address(gasworks),
-            value: 1e6,
-            nonce: nonce,
-            deadline: 2 ** 256 - 1
-        });
+//         SigUtils.Permit memory permit = SigUtils.Permit({
+//             owner: owner,
+//             spender: address(gasworks),
+//             value: 1e6,
+//             nonce: nonce,
+//             deadline: 2 ** 256 - 1
+//         });
 
-        bytes32 digest = sigUtils.getTypedDataHash(permit);
+//         bytes32 digest = sigUtils.getTypedDataHash(permit);
 
-        (uint8 v, bytes32 r, bytes32 s) = vm.sign(ownerPrivateKey, digest);
+//         (uint8 v, bytes32 r, bytes32 s) = vm.sign(ownerPrivateKey, digest);
 
-        vm.expectRevert(abi.encodeWithSelector(IGasworks.InvalidToken.selector, address(0x123123)));
-        gasworks.mintChamberWithPermit(
-            IGasworks.PermitData(
-                address(0x123123),
-                1e6,
-                permit.owner,
-                permit.spender,
-                permit.value,
-                permit.deadline,
-                v,
-                r,
-                s
-            ),
-            mintData,
-            _contractCallInstructions
-        );
-    }
+//         vm.expectRevert(abi.encodeWithSelector(IGasworks.InvalidToken.selector, address(0x123123)));
+//         gasworks.mintChamberWithPermit(
+//             IGasworks.PermitData(
+//                 address(0x123123),
+//                 1e6,
+//                 permit.owner,
+//                 permit.spender,
+//                 permit.value,
+//                 permit.deadline,
+//                 v,
+//                 r,
+//                 s
+//             ),
+//             mintData,
+//             _contractCallInstructions
+//         );
+//     }
 
-    /*//////////////////////////////////////////////////////////////
-                              SUCCESS
-    //////////////////////////////////////////////////////////////*/
+//     /*//////////////////////////////////////////////////////////////
+//                               SUCCESS
+//     //////////////////////////////////////////////////////////////*/
 
-    /**
-     * [SUCCESS] Should make a mint of AAGG with USDC using EIP2612 permit
-     */
-    function testMintChamberWithMaxPermit() public {
-        (
-            ITradeIssuerV2.ContractCallInstruction[] memory _contractCallInstructions,
-            uint256 _maxPayAmount
-        ) = abi.decode(res, (ITradeIssuerV2.ContractCallInstruction[], uint256));
-        mintData = IGasworks.MintChamberData(
-            AAGG,
-            IIssuerWizard(0x60F56236CD3C1Ac146BD94F2006a1335BaA4c449),
-            USDC,
-            _maxPayAmount,
-            amountToMint
-        );
+//     /**
+//      * [SUCCESS] Should make a mint of AAGG with USDC using EIP2612 permit
+//      */
+//     function testMintChamberWithMaxPermit() public {
+//         (
+//             ITradeIssuerV2.ContractCallInstruction[] memory _contractCallInstructions,
+//             uint256 _maxPayAmount
+//         ) = abi.decode(res, (ITradeIssuerV2.ContractCallInstruction[], uint256));
+//         mintData = IGasworks.MintChamberData(
+//             AAGG,
+//             IIssuerWizard(0x60F56236CD3C1Ac146BD94F2006a1335BaA4c449),
+//             USDC,
+//             _maxPayAmount,
+//             amountToMint
+//         );
 
-        SigUtils.Permit memory permit = SigUtils.Permit({
-            owner: owner,
-            spender: address(gasworks),
-            value: type(uint256).max,
-            nonce: nonce,
-            deadline: 2 ** 256 - 1
-        });
+//         SigUtils.Permit memory permit = SigUtils.Permit({
+//             owner: owner,
+//             spender: address(gasworks),
+//             value: type(uint256).max,
+//             nonce: nonce,
+//             deadline: 2 ** 256 - 1
+//         });
 
-        bytes32 digest = sigUtils.getTypedDataHash(permit);
+//         bytes32 digest = sigUtils.getTypedDataHash(permit);
 
-        (uint8 v, bytes32 r, bytes32 s) = vm.sign(ownerPrivateKey, digest);
+//         (uint8 v, bytes32 r, bytes32 s) = vm.sign(ownerPrivateKey, digest);
 
-        gasworks.mintChamberWithPermit(
-            IGasworks.PermitData(
-                address(USDC),
-                mintData._maxPayAmount,
-                permit.owner,
-                permit.spender,
-                permit.value,
-                permit.deadline,
-                v,
-                r,
-                s
-            ),
-            mintData,
-            _contractCallInstructions
-        );
+//         gasworks.mintChamberWithPermit(
+//             IGasworks.PermitData(
+//                 address(USDC),
+//                 mintData._maxPayAmount,
+//                 permit.owner,
+//                 permit.spender,
+//                 permit.value,
+//                 permit.deadline,
+//                 v,
+//                 r,
+//                 s
+//             ),
+//             mintData,
+//             _contractCallInstructions
+//         );
 
-        assertEq(USDC.balanceOf(address(gasworks)), 0);
-        assertGe(
-            USDC.allowance(owner, address(gasworks)), type(uint256).max - mintData._maxPayAmount
-        );
-        assertEq(IERC20Permit(address(USDC)).nonces(owner), 1);
-        assertEq(IERC20(address(AAGG)).balanceOf(owner), amountToMint);
-    }
-}
+//         assertEq(USDC.balanceOf(address(gasworks)), 0);
+//         assertGe(
+//             USDC.allowance(owner, address(gasworks)), type(uint256).max - mintData._maxPayAmount
+//         );
+//         assertEq(IERC20Permit(address(USDC)).nonces(owner), 1);
+//         assertEq(IERC20(address(AAGG)).balanceOf(owner), amountToMint);
+//     }
+// }

--- a/test/permit2/Chambers/mintChamberWithPermit2.t.sol
+++ b/test/permit2/Chambers/mintChamberWithPermit2.t.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.17.0;
 
 import { Test } from "forge-std/Test.sol";
+import { console } from "forge-std/console.sol";
 import { Gasworks } from "src/Gasworks.sol";
 import { IGasworks } from "src/interfaces/IGasworks.sol";
 import { ERC20 } from "solmate/src/tokens/ERC20.sol";
@@ -29,16 +30,32 @@ contract GaslessTest is Test, Permit2Utils, ChamberTestUtils, DeployPermit2 {
         keccak256("TokenPermissions(address token,uint256 amount)");
 
     Gasworks internal gasworks;
-    IERC20 internal constant USDC = IERC20(0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48);
-    IChamber internal constant ADDY = IChamber(0xE15A66b7B8e385CAa6F69FD0d55984B96D7263CF);
+    address internal constant usdcAddressOnEthereum = 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48;
+    address internal constant addyAdderssOnEthereum = 0xE15A66b7B8e385CAa6F69FD0d55984B96D7263CF;
+    address internal constant issuerWizardAddress = 0x60F56236CD3C1Ac146BD94F2006a1335BaA4c449;
+    address internal constant tradeIssuerV2OnEthereum = 0xbbCA2AcBd87Ce7A5e01fb56914d41F6a7e5C5A56;
+
+    ERC20 internal constant USDC = ERC20(usdcAddressOnEthereum);
+    IChamber internal constant ADDY = IChamber(addyAdderssOnEthereum);
 
     uint256 internal ownerPrivateKey;
     address internal owner;
-    IGasworks.MintChamberData internal mintData;
+    
     bytes32 internal domainSeparator;
     address internal permit2;
-    bytes internal res;
-    uint256 internal amountToMint = 100e18;
+    // bytes internal res;
+    uint256 internal amountToMint = 10e18;
+    bytes res;
+    
+
+    //Permit2 witness types
+    bytes internal constant TOKEN_PERMISSIONS_TYPE = "TokenPermissions(address token,uint256 amount)";
+    bytes internal constant PERMIT_WITNESS_TRANSFER_FROM_TYPE = "PermitWitnessTransferFrom(TokenPermissions permitted,address spender,uint256 nonce,uint256 deadline,";
+    // MintChamber
+    bytes private constant CONTRACT_CALL_INSTRUCTION_TYPE = "ContractCallInstruction(address contractTarget, address allowanceTarget, address sellToken, address sellAmount, address buyToken, uint256 minBuyAmount, bytes callData)";
+    bytes private constant MINT_CHAMBER_DATA_TYPE = "MintChamberData(address chamber,uint256 chamberAmount,address inputToken,uint256 inputTokenMaxAmount,address issuerWizard,ContractCallInstruction[] tradeIssuerCallInstructions)";
+    string internal constant PERMIT2_MINT_CHAMBER_DATA_TYPE = string(abi.encodePacked("MintChamberData witness)", MINT_CHAMBER_DATA_TYPE, CONTRACT_CALL_INSTRUCTION_TYPE, TOKEN_PERMISSIONS_TYPE));
+    
 
     /*//////////////////////////////////////////////////////////////
                               SET UP
@@ -47,194 +64,205 @@ contract GaslessTest is Test, Permit2Utils, ChamberTestUtils, DeployPermit2 {
         gasworks = new Gasworks(
             0xdA78a11FD57aF7be2eDD804840eA7f4c2A38801d, 
             0x1c0c05a2aA31692e5dc9511b04F651db9E4d8320, 
-            0xbbCA2AcBd87Ce7A5e01fb56914d41F6a7e5C5A56
+            tradeIssuerV2OnEthereum
         );
-        gasworks.setTokens(address(USDC));
-        gasworks.setTokens(address(ADDY));
+        gasworks.setTokens(usdcAddressOnEthereum);
+        gasworks.setTokens(addyAdderssOnEthereum);
         permit2 = deployPermit2();
         domainSeparator = EIP712(permit2).DOMAIN_SEPARATOR();
 
         ownerPrivateKey = 0xA11CE;
         owner = vm.addr(ownerPrivateKey);
 
+        deal(usdcAddressOnEthereum, owner, 10000e6);
+
+        vm.prank(owner);
+        USDC.approve(permit2, type(uint256).max);
+
         string[] memory inputs = new string[](6);
         inputs[0] = "node";
         inputs[1] = "scripts/fetch-arch-quote.js";
         inputs[2] = Conversor.iToHex(abi.encode(amountToMint));
-        inputs[3] = Conversor.iToHex(abi.encode(address(ADDY)));
-        inputs[4] = Conversor.iToHex(abi.encode(address(USDC)));
+        inputs[3] = Conversor.iToHex(abi.encode(addyAdderssOnEthereum));
+        inputs[4] = Conversor.iToHex(abi.encode(usdcAddressOnEthereum));
         inputs[5] = Conversor.iToHex(abi.encode(true));
         res = vm.ffi(inputs);
 
-        deal(address(USDC), owner, 1500e6);
-
-        vm.prank(owner);
-        USDC.approve(permit2, type(uint256).max);
+        vm.label(0xE15A66b7B8e385CAa6F69FD0d55984B96D7263CF, "yvUSDC");
+        vm.label(0x3B27F92C0e212C671EA351827EDF93DB27cc0c65, "yvUSDT");
+        vm.label(0xE15A66b7B8e385CAa6F69FD0d55984B96D7263CF, "yvDAI");
+        vm.label(usdcAddressOnEthereum, "USDC");
+        vm.label(0xdAC17F958D2ee523a2206206994597C13D831ec7, "USDT");
+        vm.label(0x6B175474E89094C44Da98b954EedeAC495271d0F, "DAI");
+        vm.label(addyAdderssOnEthereum, "ADDY");
+        vm.label(issuerWizardAddress, "IssuerWizard");
+        vm.label(tradeIssuerV2OnEthereum, "TraderIssuerV2");
     }
 
-    /*//////////////////////////////////////////////////////////////
-                              REVERT
-    //////////////////////////////////////////////////////////////*/
 
-    /**
-     * [REVERT] Should revert because the signature length is invalid
-     */
-    function testCannotMintChamberWithPermit2InvalidSignatureLength() public {
-        (
-            ITradeIssuerV2.ContractCallInstruction[] memory _contractCallInstructions,
-            uint256 _maxPayAmount
-        ) = abi.decode(res, (ITradeIssuerV2.ContractCallInstruction[], uint256));
-        mintData = IGasworks.MintChamberData(
-            ADDY,
-            IIssuerWizard(0x60F56236CD3C1Ac146BD94F2006a1335BaA4c449),
-            USDC,
-            _maxPayAmount,
-            amountToMint
-        );
+    // /*//////////////////////////////////////////////////////////////
+    //                           REVERT
+    // //////////////////////////////////////////////////////////////*/
 
-        uint256 currentNonce = ERC20(address(USDC)).nonces(owner);
-        ISignatureTransfer.PermitTransferFrom memory permit =
-            defaultERC20PermitTransfer(address(USDC), currentNonce, _maxPayAmount);
-        bytes memory signature = getSignature(
-            permit, ownerPrivateKey, domainSeparator, TOKEN_PERMISSIONS_TYPEHASH, address(gasworks)
-        );
-        bytes memory sigExtra = bytes.concat(signature, bytes1(uint8(0)));
-        assertEq(sigExtra.length, 66);
+    // /**
+    //  * [REVERT] Should revert because the signature length is invalid
+    //  */
+    // function testCannotMintChamberWithPermit2InvalidSignatureLength() public {
+    //     (
+    //         ITradeIssuerV2.ContractCallInstruction[] memory _contractCallInstructions,
+    //         uint256 _maxPayAmount
+    //     ) = abi.decode(res, (ITradeIssuerV2.ContractCallInstruction[], uint256));
+    //     mintData = IGasworks.MintChamberData(
+    //         ADDY,
+    //         IIssuerWizard(0x60F56236CD3C1Ac146BD94F2006a1335BaA4c449),
+    //         USDC,
+    //         _maxPayAmount,
+    //         amountToMint
+    //     );
 
-        vm.expectRevert(SignatureVerification.InvalidSignatureLength.selector);
-        gasworks.mintChamberWithPermit2(
-            permit, owner, sigExtra, mintData, _contractCallInstructions
-        );
-    }
+    //     uint256 currentNonce = ERC20(address(USDC)).nonces(owner);
+    //     ISignatureTransfer.PermitTransferFrom memory permit =
+    //         defaultERC20PermitTransfer(address(USDC), currentNonce, _maxPayAmount);
+    //     bytes memory signature = getSignature(
+    //         permit, ownerPrivateKey, domainSeparator, TOKEN_PERMISSIONS_TYPEHASH, address(gasworks)
+    //     );
+    //     bytes memory sigExtra = bytes.concat(signature, bytes1(uint8(0)));
+    //     assertEq(sigExtra.length, 66);
 
-    /**
-     * [REVERT] Should revert because the nonce was used twice and should only be used once
-     */
-    function testCannotMintChamberWithPermit2InvalidNonce() public {
-        (
-            ITradeIssuerV2.ContractCallInstruction[] memory _contractCallInstructions,
-            uint256 _maxPayAmount
-        ) = abi.decode(res, (ITradeIssuerV2.ContractCallInstruction[], uint256));
-        mintData = IGasworks.MintChamberData(
-            ADDY,
-            IIssuerWizard(0x60F56236CD3C1Ac146BD94F2006a1335BaA4c449),
-            USDC,
-            _maxPayAmount,
-            amountToMint
-        );
+    //     vm.expectRevert(SignatureVerification.InvalidSignatureLength.selector);
+    //     gasworks.mintChamberWithPermit2(
+    //         permit, owner, sigExtra, mintData, _contractCallInstructions
+    //     );
+    // }
 
-        uint256 currentNonce = ERC20(address(USDC)).nonces(owner);
-        ISignatureTransfer.PermitTransferFrom memory permit =
-            defaultERC20PermitTransfer(address(USDC), currentNonce, _maxPayAmount);
-        bytes memory signature = getSignature(
-            permit, ownerPrivateKey, domainSeparator, TOKEN_PERMISSIONS_TYPEHASH, address(gasworks)
-        );
+    // /**
+    //  * [REVERT] Should revert because the nonce was used twice and should only be used once
+    //  */
+    // function testCannotMintChamberWithPermit2InvalidNonce() public {
+    //     (
+    //         ITradeIssuerV2.ContractCallInstruction[] memory _contractCallInstructions,
+    //         uint256 _maxPayAmount
+    //     ) = abi.decode(res, (ITradeIssuerV2.ContractCallInstruction[], uint256));
+    //     mintData = IGasworks.MintChamberData(
+    //         ADDY,
+    //         IIssuerWizard(0x60F56236CD3C1Ac146BD94F2006a1335BaA4c449),
+    //         USDC,
+    //         _maxPayAmount,
+    //         amountToMint
+    //     );
 
-        gasworks.mintChamberWithPermit2(
-            permit, owner, signature, mintData, _contractCallInstructions
-        );
+    //     uint256 currentNonce = ERC20(address(USDC)).nonces(owner);
+    //     ISignatureTransfer.PermitTransferFrom memory permit =
+    //         defaultERC20PermitTransfer(address(USDC), currentNonce, _maxPayAmount);
+    //     bytes memory signature = getSignature(
+    //         permit, ownerPrivateKey, domainSeparator, TOKEN_PERMISSIONS_TYPEHASH, address(gasworks)
+    //     );
 
-        vm.expectRevert(InvalidNonce.selector);
-        gasworks.mintChamberWithPermit2(
-            permit, owner, signature, mintData, _contractCallInstructions
-        );
-    }
+    //     gasworks.mintChamberWithPermit2(
+    //         permit, owner, signature, mintData, _contractCallInstructions
+    //     );
 
-    /**
-     * [REVERT] Should revert because the signature is expired
-     */
-    function testCannotMintChamberWithPermit2SignatureExpired() public {
-        (
-            ITradeIssuerV2.ContractCallInstruction[] memory _contractCallInstructions,
-            uint256 _maxPayAmount
-        ) = abi.decode(res, (ITradeIssuerV2.ContractCallInstruction[], uint256));
-        mintData = IGasworks.MintChamberData(
-            ADDY,
-            IIssuerWizard(0x60F56236CD3C1Ac146BD94F2006a1335BaA4c449),
-            USDC,
-            _maxPayAmount,
-            amountToMint
-        );
+    //     vm.expectRevert(InvalidNonce.selector);
+    //     gasworks.mintChamberWithPermit2(
+    //         permit, owner, signature, mintData, _contractCallInstructions
+    //     );
+    // }
 
-        uint256 currentNonce = ERC20(address(USDC)).nonces(owner);
-        ISignatureTransfer.PermitTransferFrom memory permit =
-            defaultERC20PermitTransfer(address(USDC), currentNonce, _maxPayAmount);
-        permit.deadline = 2 ** 255 - 1;
-        bytes memory signature = getSignature(
-            permit, ownerPrivateKey, domainSeparator, TOKEN_PERMISSIONS_TYPEHASH, address(gasworks)
-        );
+    // /**
+    //  * [REVERT] Should revert because the signature is expired
+    //  */
+    // function testCannotMintChamberWithPermit2SignatureExpired() public {
+    //     (
+    //         ITradeIssuerV2.ContractCallInstruction[] memory _contractCallInstructions,
+    //         uint256 _maxPayAmount
+    //     ) = abi.decode(res, (ITradeIssuerV2.ContractCallInstruction[], uint256));
+    //     mintData = IGasworks.MintChamberData(
+    //         ADDY,
+    //         IIssuerWizard(0x60F56236CD3C1Ac146BD94F2006a1335BaA4c449),
+    //         USDC,
+    //         _maxPayAmount,
+    //         amountToMint
+    //     );
 
-        vm.warp(2 ** 255 + 1);
+    //     uint256 currentNonce = ERC20(address(USDC)).nonces(owner);
+    //     ISignatureTransfer.PermitTransferFrom memory permit =
+    //         defaultERC20PermitTransfer(address(USDC), currentNonce, _maxPayAmount);
+    //     permit.deadline = 2 ** 255 - 1;
+    //     bytes memory signature = getSignature(
+    //         permit, ownerPrivateKey, domainSeparator, TOKEN_PERMISSIONS_TYPEHASH, address(gasworks)
+    //     );
 
-        vm.expectRevert(abi.encodeWithSelector(SignatureExpired.selector, permit.deadline));
-        gasworks.mintChamberWithPermit2(
-            permit, owner, signature, mintData, _contractCallInstructions
-        );
-    }
+    //     vm.warp(2 ** 255 + 1);
 
-    /**
-     * [REVERT] Should revert because the mintData is invalid
-     */
-    function testCannotMintChamberWithPermit2InvalidPayload() public {
-        (
-            ITradeIssuerV2.ContractCallInstruction[] memory _contractCallInstructions,
-            uint256 _maxPayAmount
-        ) = abi.decode(res, (ITradeIssuerV2.ContractCallInstruction[], uint256));
-        mintData = IGasworks.MintChamberData(
-            ADDY,
-            IIssuerWizard(0x60F56236CD3C1Ac146BD94F2006a1335BaA4c449),
-            USDC,
-            _maxPayAmount,
-            amountToMint
-        );
+    //     vm.expectRevert(abi.encodeWithSelector(SignatureExpired.selector, permit.deadline));
+    //     gasworks.mintChamberWithPermit2(
+    //         permit, owner, signature, mintData, _contractCallInstructions
+    //     );
+    // }
 
-        _contractCallInstructions[0]._callData = bytes("bad data");
+    // /**
+    //  * [REVERT] Should revert because the mintData is invalid
+    //  */
+    // function testCannotMintChamberWithPermit2InvalidPayload() public {
+    //     (
+    //         ITradeIssuerV2.ContractCallInstruction[] memory _contractCallInstructions,
+    //         uint256 _maxPayAmount
+    //     ) = abi.decode(res, (ITradeIssuerV2.ContractCallInstruction[], uint256));
+    //     mintData = IGasworks.MintChamberData(
+    //         ADDY,
+    //         IIssuerWizard(0x60F56236CD3C1Ac146BD94F2006a1335BaA4c449),
+    //         USDC,
+    //         _maxPayAmount,
+    //         amountToMint
+    //     );
 
-        uint256 currentNonce = ERC20(address(USDC)).nonces(owner);
-        ISignatureTransfer.PermitTransferFrom memory permit =
-            defaultERC20PermitTransfer(address(USDC), currentNonce, _maxPayAmount);
-        bytes memory signature = getSignature(
-            permit, ownerPrivateKey, domainSeparator, TOKEN_PERMISSIONS_TYPEHASH, address(gasworks)
-        );
+    //     _contractCallInstructions[0]._callData = bytes("bad data");
 
-        vm.expectRevert();
-        gasworks.mintChamberWithPermit2(
-            permit, owner, signature, mintData, _contractCallInstructions
-        );
-    }
+    //     uint256 currentNonce = ERC20(address(USDC)).nonces(owner);
+    //     ISignatureTransfer.PermitTransferFrom memory permit =
+    //         defaultERC20PermitTransfer(address(USDC), currentNonce, _maxPayAmount);
+    //     bytes memory signature = getSignature(
+    //         permit, ownerPrivateKey, domainSeparator, TOKEN_PERMISSIONS_TYPEHASH, address(gasworks)
+    //     );
 
-    /**
-     * [REVERT] Should revert because sellToken is not permitted
-     */
-    function testCannotMintChamberWithPermit2InvalidToken() public {
-        (
-            ITradeIssuerV2.ContractCallInstruction[] memory _contractCallInstructions,
-            uint256 _maxPayAmount
-        ) = abi.decode(res, (ITradeIssuerV2.ContractCallInstruction[], uint256));
-        mintData = IGasworks.MintChamberData(
-            ADDY,
-            IIssuerWizard(0x60F56236CD3C1Ac146BD94F2006a1335BaA4c449),
-            USDC,
-            _maxPayAmount,
-            amountToMint
-        );
+    //     vm.expectRevert();
+    //     gasworks.mintChamberWithPermit2(
+    //         permit, owner, signature, mintData, _contractCallInstructions
+    //     );
+    // }
 
-        uint256 currentNonce = ERC20(address(USDC)).nonces(owner);
-        ISignatureTransfer.PermitTransferFrom memory permit =
-            defaultERC20PermitTransfer(0x8f3Cf7ad23Cd3CaDbD9735AFf958023239c6A063, currentNonce, 1e1);
-        bytes memory signature = getSignature(
-            permit, ownerPrivateKey, domainSeparator, TOKEN_PERMISSIONS_TYPEHASH, address(gasworks)
-        );
+    // /**
+    //  * [REVERT] Should revert because sellToken is not permitted
+    //  */
+    // function testCannotMintChamberWithPermit2InvalidToken() public {
+    //     (
+    //         ITradeIssuerV2.ContractCallInstruction[] memory _contractCallInstructions,
+    //         uint256 _maxPayAmount
+    //     ) = abi.decode(res, (ITradeIssuerV2.ContractCallInstruction[], uint256));
+    //     mintData = IGasworks.MintChamberData(
+    //         ADDY,
+    //         IIssuerWizard(0x60F56236CD3C1Ac146BD94F2006a1335BaA4c449),
+    //         USDC,
+    //         _maxPayAmount,
+    //         amountToMint
+    //     );
 
-        vm.expectRevert(
-            abi.encodeWithSelector(
-                IGasworks.InvalidToken.selector, 0x8f3Cf7ad23Cd3CaDbD9735AFf958023239c6A063
-            )
-        );
-        gasworks.mintChamberWithPermit2(
-            permit, owner, signature, mintData, _contractCallInstructions
-        );
-    }
+    //     uint256 currentNonce = ERC20(address(USDC)).nonces(owner);
+    //     ISignatureTransfer.PermitTransferFrom memory permit =
+    //         defaultERC20PermitTransfer(0x8f3Cf7ad23Cd3CaDbD9735AFf958023239c6A063, currentNonce, 1e1);
+    //     bytes memory signature = getSignature(
+    //         permit, ownerPrivateKey, domainSeparator, TOKEN_PERMISSIONS_TYPEHASH, address(gasworks)
+    //     );
+
+    //     vm.expectRevert(
+    //         abi.encodeWithSelector(
+    //             IGasworks.InvalidToken.selector, 0x8f3Cf7ad23Cd3CaDbD9735AFf958023239c6A063
+    //         )
+    //     );
+    //     gasworks.mintChamberWithPermit2(
+    //         permit, owner, signature, mintData, _contractCallInstructions
+    //     );
+    // }
 
     /*//////////////////////////////////////////////////////////////
                               SUCCESS
@@ -244,29 +272,107 @@ contract GaslessTest is Test, Permit2Utils, ChamberTestUtils, DeployPermit2 {
      * [SUCCESS] Should make a mint of ADDY with USDC using permit2
      */
     function testMintChamberWithPermit2() public {
+        IGasworks.MintChamberData memory mintChamberData;
+
         (
             ITradeIssuerV2.ContractCallInstruction[] memory _contractCallInstructions,
             uint256 _maxPayAmount
         ) = abi.decode(res, (ITradeIssuerV2.ContractCallInstruction[], uint256));
-        mintData = IGasworks.MintChamberData(
-            ADDY,
-            IIssuerWizard(0x60F56236CD3C1Ac146BD94F2006a1335BaA4c449),
-            USDC,
-            _maxPayAmount,
-            amountToMint
+
+        IGasworks.ContractCallInstruction[] memory tradeIssuerCallInstructions = new IGasworks.ContractCallInstruction[](_contractCallInstructions.length);
+
+        for (uint256 i = 0; i < _contractCallInstructions.length;) {
+          IGasworks.ContractCallInstruction memory instruction = IGasworks.ContractCallInstruction(
+            _contractCallInstructions[i]._target,
+            _contractCallInstructions[i]._allowanceTarget,
+            address(_contractCallInstructions[i]._sellToken),
+            _contractCallInstructions[i]._sellAmount,
+            address(_contractCallInstructions[i]._buyToken),
+            _contractCallInstructions[i]._minBuyAmount,
+            _contractCallInstructions[i]._callData
+          );
+
+          tradeIssuerCallInstructions[i] = instruction;
+          unchecked {
+            ++i;
+          }
+        }
+
+        mintChamberData = IGasworks.MintChamberData(
+          addyAdderssOnEthereum,
+          amountToMint,
+          usdcAddressOnEthereum,
+          _maxPayAmount,
+          address(issuerWizardAddress),
+          tradeIssuerCallInstructions
         );
 
-        uint256 currentNonce = ERC20(address(USDC)).nonces(owner);
+
+        uint256 currentNonce = USDC.nonces(owner);
+
         ISignatureTransfer.PermitTransferFrom memory permit =
-            defaultERC20PermitTransfer(address(USDC), currentNonce, _maxPayAmount);
-        bytes memory signature = getSignature(
-            permit, ownerPrivateKey, domainSeparator, TOKEN_PERMISSIONS_TYPEHASH, address(gasworks)
-        );
+        ISignatureTransfer.PermitTransferFrom({
+            permitted: ISignatureTransfer.TokenPermissions({token: usdcAddressOnEthereum, amount: _maxPayAmount}),
+            nonce: currentNonce,
+            deadline: block.timestamp + 100
+        });
+
+        bytes memory concatenatedHashedTradeIssuerCallInstructions;
+        for (uint256 i = 0; i < mintChamberData.tradeIssuerCallInstructions.length;) {
+          bytes32 hashedTradeIssuerCallInstruction = keccak256(abi.encode(
+            keccak256(abi.encodePacked(CONTRACT_CALL_INSTRUCTION_TYPE)),
+            mintChamberData.tradeIssuerCallInstructions[i].contractTarget,
+            mintChamberData.tradeIssuerCallInstructions[i].allowanceTarget,
+            mintChamberData.tradeIssuerCallInstructions[i].sellToken,
+            mintChamberData.tradeIssuerCallInstructions[i].sellAmount,
+            mintChamberData.tradeIssuerCallInstructions[i].buyToken,
+            mintChamberData.tradeIssuerCallInstructions[i].minBuyAmount,
+            keccak256(mintChamberData.tradeIssuerCallInstructions[i].callData)
+          ));
+
+          concatenatedHashedTradeIssuerCallInstructions = bytes.concat(concatenatedHashedTradeIssuerCallInstructions, hashedTradeIssuerCallInstruction);
+          unchecked {
+            ++i;
+          }
+        }
+
+        bytes32 witness = keccak256(abi.encode(
+          keccak256(abi.encodePacked(MINT_CHAMBER_DATA_TYPE)),
+          mintChamberData.chamber,
+          mintChamberData.chamberAmount,
+          mintChamberData.inputToken,
+          mintChamberData.inputTokenMaxAmount,
+          mintChamberData.issuerWizard,
+          keccak256(concatenatedHashedTradeIssuerCallInstructions)
+        ));
+
+        // bytes32 domainSeparator = keccak256(abi.encode(TYPE_HASH, NAME_HASH, block.chainid, usdcAddressOnEthereum));
+        bytes32 tokenPermissions = keccak256(abi.encode(TOKEN_PERMISSIONS_TYPEHASH, permit.permitted));
+        bytes32 msgHash = keccak256(abi.encodePacked(
+            "\x19\x01",
+            domainSeparator,
+            keccak256(
+                abi.encode(
+                    keccak256(abi.encodePacked(PERMIT_WITNESS_TRANSFER_FROM_TYPE, PERMIT2_MINT_CHAMBER_DATA_TYPE)),
+                    tokenPermissions,
+                    address(gasworks),
+                    permit.nonce,
+                    permit.deadline,
+                    witness
+                )
+            )
+        ));
+
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(ownerPrivateKey, msgHash);
+        bytes memory signature = bytes.concat(r, s, bytes1(v));
 
         gasworks.mintChamberWithPermit2(
-            permit, owner, signature, mintData, _contractCallInstructions
+            permit,
+            owner,
+            signature,
+            mintChamberData
         );
 
-        assertEq(IERC20(address(ADDY)).balanceOf(owner), amountToMint);
+        assertEq(IERC20(addyAdderssOnEthereum).balanceOf(owner), amountToMint);
     }
 }

--- a/test/permit2/swapWithPermit2.t.sol
+++ b/test/permit2/swapWithPermit2.t.sol
@@ -37,11 +37,12 @@ contract GaslessTest is Test, Permit2Utils, DeployPermit2 {
     bytes32 internal domainSeparator;
     address internal permit2;
 
-    bytes internal constant PERMIT_WITNESS_TRANSFER_FROM_TYPE = "PermitWitnessTransferFrom(TokenPermissions permitted,address spender,uint256 nonce,uint256 deadline,";
-    bytes internal constant SWAP_DATA_TYPE = "SwapData(address buyToken,address spender,address swapTarget,bytes swapCallData,uint256 swapValue,uint256 buyAmount)";
+    //Permit2 witness types
     bytes internal constant TOKEN_PERMISSIONS_TYPE = "TokenPermissions(address token,uint256 amount)";
+    bytes internal constant PERMIT_WITNESS_TRANSFER_FROM_TYPE = "PermitWitnessTransferFrom(TokenPermissions permitted,address spender,uint256 nonce,uint256 deadline,";
+    // Swap
+    bytes internal constant SWAP_DATA_TYPE = "SwapData(address buyToken,address spender,address swapTarget,bytes swapCallData,uint256 swapValue,uint256 buyAmount)";
     bytes internal constant PERMIT2_SWAP_DATA_TYPE = abi.encodePacked("SwapData witness)", SWAP_DATA_TYPE, TOKEN_PERMISSIONS_TYPE);
-
 
     /*//////////////////////////////////////////////////////////////
                               SET UP


### PR DESCRIPTION
- Change `MintChamberData` struct to be readable for the user, leaving the quotes array to the last and the important data first. Renamed variables also.
- Reusing TradeIssuerV2.CallInstructions inside EIP-712 would have been a pain in the ass, so I created a direct struct in IGasworks, a.k.a `MintChameberData`
- The abova change broke permit2 functions and tests so I commented them
- Working use case in test